### PR TITLE
Fix 24 hour time conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Source code to [Dave's Garage](https://www.youtube.com/c/DavesGarage/featured) v
 This repository's code targets the ca65 assembler and cl65 linker that are part of the [cc65](https://cc65.github.io/) GitHub project. You will need a fairly recent build of cc65 for assembly of this repository's contents to work.
 
 With the cc65 toolkit installed and in your PATH, you can build the application using the following command:
-```
+
+```text
 cl65 -o petclock.prg -t none petclock.asm
 ```
+
+## 6502 assembly
+
+For those who would like more information about the 6502 CPU and/or about writing assembly code for it, the folks at [6502.org](6502.org) have compiled a lot of resources on the topic. Amongst others, there is a page that contains [links to tutorials and primers](http://www.6502.org/tutorials/), which itself links to a [detailed description of the 6502 opcodes](http://www.6502.org/tutorials/6502opcodes.html) used in the PET clock source code.

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ cl65 -o petclock.prg -t none petclock.asm
 
 ## 6502 assembly
 
-For those who would like more information about the 6502 CPU and/or about writing assembly code for it, the folks at [6502.org](6502.org) have compiled a lot of resources on the topic. Amongst others, there is a page that contains [links to tutorials and primers](http://www.6502.org/tutorials/), which itself links to a [detailed description of the 6502 opcodes](http://www.6502.org/tutorials/6502opcodes.html) used in the PET clock source code.
+For those who would like more information about the 6502 CPU and/or about writing assembly code for it, the folks at [6502.org](http://www.6502.org) have compiled a lot of resources on the topic. Amongst others, there is a page that contains [links to tutorials and primers](http://www.6502.org/tutorials/), which itself links to a [detailed description of the 6502 opcodes](http://www.6502.org/tutorials/6502opcodes.html) used in the PET clock source code.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Source code to [Dave's Garage](https://www.youtube.com/c/DavesGarage/featured) v
 
 [![Assembly Language Snow Day! Learn ASM Now! | Dave's Garage](https://img.youtube.com/vi/CfbciNZvg0o/0.jpg)](https://youtu.be/CfbciNZvg0o)
 
-## Assembler
+## Building
 
 This repository's code targets the ca65 assembler and cl65 linker that are part of the [cc65](https://cc65.github.io/) GitHub project. You will need a fairly recent build of cc65 for assembly of this repository's contents to work.
+With the cc65 toolkit installed and in your PATH, you can build the application using the following command:
+```
+cl65 -o petclock.prg -t none petclock.asm
+```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Source code to [Dave's Garage](https://www.youtube.com/c/DavesGarage/featured) v
 ## Building
 
 This repository's code targets the ca65 assembler and cl65 linker that are part of the [cc65](https://cc65.github.io/) GitHub project. You will need a fairly recent build of cc65 for assembly of this repository's contents to work.
+
 With the cc65 toolkit installed and in your PATH, you can build the application using the following command:
 ```
 cl65 -o petclock.prg -t none petclock.asm

--- a/petclock.asm
+++ b/petclock.asm
@@ -327,12 +327,11 @@ TwoInTens:      dec HourTens            ; If it's 2X:XX we go back 12 hours
                 adc #8                  ;   there, it's the same as adding 8 to
                                         ;   hours digit while clearing the tens.
 
-                cmp #':'                ; If we have a digits value <= 9, then
+                cmp #'9'+1              ; If we have a digits value <= 9, then
                 bcc @donedigits         ;   we're done here. Otherwise,
-                inc HourTens            ;   we increase the tens value to 1
-                sbc #10                 ;   and subtract 10 from the current
-                                        ;   digits value 
-
+                sbc #10                 ;   subtract 10 from the digits
+                inc HourTens            ;   and increase the tens value to 1
+ 
 @donedigits:    sta HourDigits          ; We're good to store our hour digits
                 rts
 

--- a/petclock.asm
+++ b/petclock.asm
@@ -325,7 +325,15 @@ TwoInTens:      dec HourTens            ; If it's 2X:XX we go back 12 hours
                 lda HourDigits          ;   20 hours to the hours digit.  So by
                 clc                     ;   adding 20 and then going back 12 from
                 adc #8                  ;   there, it's the same as adding 8 to
-                sta HourDigits          ;   hours digit while clearing the tens.
+                                        ;   hours digit while clearing the tens.
+
+                cmp #':'                ; If we have a digits value <= 9, then
+                bcc @donedigits         ;   we're done here. Otherwise,
+                inc HourTens            ;   we increase the tens value to 1
+                sbc #10                 ;   and subtract 10 from the current
+                                        ;   digits value 
+
+@donedigits:    sta HourDigits          ; We're good to store our hour digits
                 rts
 
 FakeResponse:    .literal "2017-01-09t21:23:45 MON", 0


### PR DESCRIPTION
This fixes #1, by adding a check and fix for hour digit overflow, which occurs if the 24 hour value is higher than 21.
This code has been tested in the VICE PET emulator.

Credits to @NoobTracker for identifying the issue and suggesting a fix of his own in PR #2. 