### PR TITLE
Make the clock run

### DIFF
--- a/petclock.asm
+++ b/petclock.asm
@@ -133,7 +133,8 @@ endOfBasic:		.word 00							;   the +7 expression above, as this is
 
 start:			cld
                 jsr InitVariables       ; Since we can be in ROM, zero stuff out
-                jsr InitClock
+                jsr ZeroSeconds         ; Set clock to 0 seconds in the minute
+                jsr LoadClock
 MainLoop:		
                 ldy ClockYPos			
                 ldx ClockXPos
@@ -152,7 +153,12 @@ InnerLoop:		jsr UpdateClockPos      ; Carry will be clear when its time to updat
                 bne notEscape
                 beq ExitApp				; Escape pressed, go to exit
 
-notEscape:		cmp #$48				
+notEscape:		cmp #$5A				
+                bne @notZero
+                jsr ZeroSeconds		    ; Z pressed, set seconds to 0
+                jmp MainLoop
+
+@notZero:       cmp #$48				
                 bne @notHour
                 jsr IncrementHour		; H pressed, increment hour
                 jmp MainLoop
@@ -281,16 +287,21 @@ ShowInstructions:
 @done:			rts
 
 ;-----------------------------------------------------------------------------------
-; InitClock - Sets the current time of day from hardware or a fake value
+; ZeroSeconds - (Re)sets the second zero point to now
 ;-----------------------------------------------------------------------------------
 
-InitClock:
+ZeroSeconds:
                 lda #0                  ; Set all 3 bytes of the jiffy timer to zero
                 sei                     ; with interrupts disabled
                 sta JIFFY_TIMER
                 sta JIFFY_TIMER-1
                 sta JIFFY_TIMER-2
                 cli
+                rts
+
+;-----------------------------------------------------------------------------------
+; LoadClock - Sets the current time of day from hardware or a fake value
+;-----------------------------------------------------------------------------------
 
 LoadClock:
 .if PETSDPLUS  

--- a/petclock.asm
+++ b/petclock.asm
@@ -160,7 +160,7 @@ notEscape:
                 bne @notLoad
                 jsr LoadClock           ; L pressed, load time off RTC
                 jmp @MainLoop
-                
+
 @notLoad:
 .endif
                 cmp #$5A				
@@ -181,11 +181,13 @@ notEscape:
 @notHourDn:		cmp #$4D
                 bne @notMin
                 jsr IncrementMinute		; M pressed, increment minute
+                jsr ZeroSeconds
                 jmp MainLoop
 
 @notMin:		cmp #$CD
                 bne @notMinDn
                 jsr DecrementMinute		; SHIFT-M pressed, decrement minute
+                jsr ZeroSeconds
                 jmp MainLoop
 
 @notMinDn:		jsr ShowInstructions	; Any other key shows the help text

--- a/petclock.asm
+++ b/petclock.asm
@@ -153,7 +153,17 @@ InnerLoop:		jsr UpdateClockPos      ; Carry will be clear when its time to updat
                 bne notEscape
                 beq ExitApp				; Escape pressed, go to exit
 
-notEscape:		cmp #$5A				
+notEscape:		
+
+.if PETSDPLUS
+                cmp #$4C
+                bne @notLoad
+                jsr LoadClock           ; L pressed, load time off RTC
+                jmp @MainLoop
+                
+@notLoad:
+.endif
+                cmp #$5A				
                 bne @notZero
                 jsr ZeroSeconds		    ; Z pressed, set seconds to 0
                 jmp MainLoop
@@ -396,11 +406,7 @@ UpdateClock:
                 ;                                                                 +----
                 ; Estimated jiffy timer drift in μs per applied clock update:       53
 
-.if PETSDPLUS
-                jmp LoadClock           ; If we have the RTC, load our time off that
-.else
-                jmp IncrementMinute     ; Otherwise, we increase the minute count
-.endif                
+                jmp IncrementMinute     ; Increase the minute count
 
 ;----------------------------------------------------------------------------
 ; SendCommand


### PR DESCRIPTION
This PR makes the clock actually run, in the VICE PET emulator and (presumably) a real PET, with or without a petSD+.

The jiffy timer (passing of 3600 jiffies) is used to establish when a minute has passed, at which time the minute counter is increased. 

At least on PETs without an RTC, the clock will drift for two reasons:

- The jiffy timer updates 60 times per second, but not necessarily _exactly_ 60.000000 times. It is impossible to estimate exactly how much drift is caused by this, as the exact number of jiffy updates per second is unknown, and will certainly vary in emulated scenarios.
- The manipulation of the jiffy timer by the code itself also causes a clock drift. This is estimated to be approximately 50 microseconds per minute. This means that the clock may run a minute slow after a little over 2 years. I've decided this to be acceptable.

Two additional key commands have been added:
- Z to set the (implicit) second counter to 0.
- L to load the actual time off the RTC. This command is only recognized on systems/builds with a petSD+.