### PR TITLE
Load seconds from petSD+ or jiffy clock

### DIFF
--- a/petclock.asm
+++ b/petclock.asm
@@ -642,7 +642,7 @@ UpdateJiffyClock:
 
 @addhours:      clc
 @hhloop:        lda #$c0                ; Perform a three-byte add. We're adding the number
-                adc remainder           ;   of jiffier per hour, which is 216,000 or 34b0c
+                adc remainder           ;   of jiffies per hour, which is 216,000 or 34bc0
                 sta remainder           ;   in hex.
                 lda #$4b
                 adc remainder+1

--- a/petclock.asm
+++ b/petclock.asm
@@ -436,14 +436,14 @@ TwoInTens:      dec HourTens            ; If it's 2X:XX we go back 12 hours
 
 LoadJiffyClock:
 
-                sei                     ; Save jiffy clock with interrupts disabled.
+                sei                     ; Load jiffy clock with interrupts disabled.
                 lda JIFFY_TIMER         ;   We put the low byte in the result variable
-                sta zptmp               ;   zptmp, and the two high bytes in the two 
-                lda JIFFY_TIMER-1       ;   lowest bytes of the remainder. Together with
-                sta remainder           ;   the initial rotate left below, this sets us 
-                lda JIFFY_TIMER-2       ;   up for the most efficient division to get the
-                sta remainder+1         ;   hour value out of the jiffy clock.
-                cli
+                ldx JIFFY_TIMER-1       ;   zptmp, and the two high bytes in the two 
+                ldy JIFFY_TIMER-2       ;   lowest bytes of the remainder. Together with
+                cli                     ;   the initial rotate left below, this sets us 
+                sta zptmp               ;   up for the most efficient division to get the
+                stx remainder           ;   hour value out of the jiffy clock.
+                sty remainder+1
 
                 lda #0                  ; Clear remainder high byte
                 sta remainder+2

--- a/petclock.asm
+++ b/petclock.asm
@@ -6,6 +6,16 @@
 ;-----------------------------------------------------------------------------------
 ; Environment: xpet -fs9 d:\OneDrive\PET\source\ -device9 1
 ;            : PET 2001
+;-----------------------------------------------------------------------------------
+; On PETs that don't have a petSD+, the clock will be initialized from the internal
+; system (jiffy) clock in the PET. The system clock can be initialized in BASIC 
+; before running this clock, by issuing the following command:
+;
+; TI$="HHMMSS"
+;
+; The hours can be specified in 24-hour format; they will be converted to 12-hour
+; format, as is the time read from the petSD+.
+
 
 .SETCPU "65C02"
 

--- a/petclock.asm
+++ b/petclock.asm
@@ -435,7 +435,6 @@ TwoInTens:      dec HourTens            ; If it's 2X:XX we go back 12 hours
 ;-----------------------------------------------------------------------------------
 
 LoadJiffyClock:
-
                 sei                     ; Load jiffy clock with interrupts disabled.
                 lda JIFFY_TIMER         ;   We put the low byte in the result variable
                 ldx JIFFY_TIMER-1       ;   zptmp, and the two high bytes in the two 
@@ -450,8 +449,7 @@ LoadJiffyClock:
                 
                 ldx #3
 
-@hhrol:	
-                rol zptmp               ; We rotate the result and remainder left 3 bits. 
+@hhrol:         rol zptmp               ; We rotate the result and remainder left 3 bits. 
                 rol remainder           ;   We do this knowing that the result can be a
                 rol remainder+1         ;   maximum of 5 bits long (max hour value is 23
                 rol remainder+2         ;   or 10111 in binary).
@@ -461,8 +459,7 @@ LoadJiffyClock:
                 
                 ldx #5                  ; We will perform a 5 step long division
 	
-@hhdiv:
-                rol zptmp               ; Rotate result and remainder left
+@hhdiv:         rol zptmp               ; Rotate result and remainder left
                 rol remainder
                 rol remainder+1
                 rol remainder+2
@@ -485,8 +482,7 @@ LoadJiffyClock:
                 tya
                 sta remainder
 	
-@hhignore:
-                dex                     ; Continue if we have more division steps to take
+@hhignore:      dex                     ; Continue if we have more division steps to take
                 bne @hhdiv
                 
                 rol zptmp               ; Don't forget to shift the last bit into the result
@@ -508,8 +504,7 @@ LoadJiffyClock:
                 
                 ldx #6                  ; Perform a 6 step long division
 	
-@mmdiv:
-                rol zptmp               ; Rotate result and remainder left
+@mmdiv:         rol zptmp               ; Rotate result and remainder left
                 rol remainder+1
                 rol remainder+2
                 
@@ -526,8 +521,7 @@ LoadJiffyClock:
                 tya                     ;   value of the remainder in memory.
                 sta remainder+1
 	
-@mmignore:	
-                dex                     ; Continue if we have more division steps to take
+@mmignore:	    dex                     ; Continue if we have more division steps to take
                 bne @mmdiv
                 
                 rol zptmp               ; Don't forget to shift the last bit into the result
@@ -547,8 +541,7 @@ LoadJiffyClock:
 
                 ldx #6                  ; 6 step long division, like before.
 	
-@secdiv:
-                rol zptmp               ; The below is a pretty straightforward long  
+@secdiv:        rol zptmp               ; The below is a pretty straightforward long  
                 rol remainder+2         ;   division of a two-byte value by 60.
                 
                 sec
@@ -559,8 +552,7 @@ LoadJiffyClock:
                 
                 sta remainder+2
 	
-@secignore:	
-                dex
+@secignore:	    dex
                 bne @secdiv
                 
                 rol zptmp
@@ -587,15 +579,13 @@ GetDigitChars:
                 
                 sec
 	
-@tensloop:
-                sbc #10                 ; Subtract 10 until we dive below zero. Every
+@tensloop:      sbc #10                 ; Subtract 10 until we dive below zero. Every
                 bcc @belowzero          ;   time we stay above zero, we increase X.
                 
                 inx
                 bcs @tensloop
 	
-@belowzero:
-                adc #'0'+10             ; Calculate digit character and put it in Y
+@belowzero:     adc #'0'+10             ; Calculate digit character and put it in Y
                 tay
                 
                 txa                     ; Pull tens out of X and calculate tens character

--- a/petclock.asm
+++ b/petclock.asm
@@ -491,9 +491,10 @@ LoadJiffyClock:
                 
                 rol zptmp               ; Don't forget to shift the last bit into the result
                 
-                jsr SplitZptmpDigits    ; Split the digits of the calculated hour value and
-                sta ClkHourTens         ;   store them in the appropriate fields.
-                stx ClkHourDigits
+                ldx zptmp
+                jsr GetDigitChars       ; Split the digits of the calculated hour value and
+                stx ClkHourTens         ;   store them in the appropriate fields.
+                sty ClkHourDigits
 
                 lda remainder           ; Bump the low byte of the remainder in the result
                 sta zptmp               ;   variable.
@@ -531,9 +532,10 @@ LoadJiffyClock:
                 
                 rol zptmp               ; Don't forget to shift the last bit into the result
 	
-                jsr SplitZptmpDigits    ; Split and store the digits of the calculated
-                sta ClkMinTens          ;   minute value.
-                stx ClkMinDigits
+                ldx zptmp
+                jsr GetDigitChars       ; Split and store the digits of the calculated
+                stx ClkMinTens          ;   minute value.
+                sty ClkMinDigits
 
                 lda remainder+1         ; Put the low byte of the remainder in the result 
                 sta zptmp               ;   variable.
@@ -563,40 +565,43 @@ LoadJiffyClock:
                 
                 rol zptmp
 	
-                jsr SplitZptmpDigits    ; Split and store the digits of the calculated  
-                sta ClkSecTens          ;   second value.
-                stx ClkSecDigits
+                ldx zptmp
+                jsr GetDigitChars       ; Split and store the digits of the calculated  
+                stx ClkSecTens          ;   second value.
+                sty ClkSecDigits
 
                 rts
 
 
 ;-----------------------------------------------------------------------------------
-; Split the tens and digits of the value in zptmp
+; Calculate the tens and digits characters of the value in X
 ;-----------------------------------------------------------------------------------
-;       OUT A:  tens character
-;       OUT X:  digit character
+;       IN  X:  value to split and convert 
+;       OUT X:  tens character
+;       OUT Y:  digit character
 ;-----------------------------------------------------------------------------------
 
-SplitZptmpDigits:
-                lda zptmp
-                ldy #0
+GetDigitChars:
+                txa
+                ldx #0
                 
                 sec
 	
 @tensloop:
                 sbc #10                 ; Subtract 10 until we dive below zero. Every
-                bcc @belowzero          ;   time we stay above zero, we increase Y.
+                bcc @belowzero          ;   time we stay above zero, we increase X.
                 
-                iny
+                inx
                 bcs @tensloop
 	
 @belowzero:
-                adc #'0'+10             ; Calculate digit character and put it in X
-                tax
+                adc #'0'+10             ; Calculate digit character and put it in Y
+                tay
                 
-                tya                     ; Pull tens out of Y and calculate tens character
+                txa                     ; Pull tens out of X and calculate tens character
                 clc
                 adc #'0'
+                tax
                 
                 rts
 

--- a/petclock.asm
+++ b/petclock.asm
@@ -485,39 +485,35 @@ LoadJiffyClock:
                 sta ClkHourTens         ;   store them in the appropriate fields.
                 stx ClkHourDigits
 
-                lda remainder           ; Bump the remainder one byte to the right, putting
-                sta zptmp               ;   the low byte in the result variable.
-                lda remainder+1
-                sta remainder
-                lda remainder+2
-                sta remainder+1
+                lda remainder           ; Bump the low byte of the remainder in the result
+                sta zptmp               ;   variable.
 
                 rol zptmp               ; Rotate left by two bits to set things up for 
-                rol remainder           ;   the calculation of the minutes. This time, the
-                rol remainder+1         ;   result can be a maximum of 6 bits long (max 
+                rol remainder+1         ;   the calculation of the minutes. This time, the
+                rol remainder+2         ;   result can be a maximum of 6 bits long (max 
                 rol zptmp               ;   minute value is 59, or 111011 in binary).
-                rol remainder
                 rol remainder+1
+                rol remainder+2
                 
                 ldx #6                  ; Perform a 6 step long division
 	
 @mmdiv:
                 rol zptmp               ; Rotate result and remainder left
-                rol remainder
                 rol remainder+1
+                rol remainder+2
                 
                 sec                     ; Subtract the number of jiffies in a minute from
-                lda remainder           ;   the current value in the remainder. That number
+                lda remainder+1         ;   the current value in the remainder. That number
                 sbc #$10                ;   is 3600, or e10 in hex.
                 tay
-                lda remainder+1
+                lda remainder+2
                 sbc #$0e
                 
                 bcc @mmignore           ; If carry was cleared, subtract wasn't possible
                 
-                sta remainder+1         ; Subtract was possible, so save the remaining
+                sta remainder+2         ; Subtract was possible, so save the remaining
                 tya                     ;   value of the remainder in memory.
-                sta remainder
+                sta remainder+1
 	
 @mmignore:	
                 dex                     ; Continue if we have more division steps to take
@@ -529,29 +525,27 @@ LoadJiffyClock:
                 sta ClkMinTens          ;   minute value.
                 stx ClkMinDigits
 
-                lda remainder           ; Bump the remainder one byte to the right, 
-                sta zptmp               ;   putting the low byte in the result variable.
-                lda remainder+1
-                sta remainder
+                lda remainder+1         ; Put the low byte of the remainder in the result 
+                sta zptmp               ;   variable.
 
                 rol zptmp               ; Like before, rotate left by two bits. Like with 
-                rol remainder           ;   minutes, the maximum value of seconds is 59.
+                rol remainder+2         ;   minutes, the maximum value of seconds is 59.
                 rol zptmp
-                rol remainder
+                rol remainder+2
 
                 ldx #6                  ; 6 step long division, like before.
 	
 @secdiv:
                 rol zptmp               ; The below is a pretty straightforward long  
-                rol remainder           ;   division of a two-byte value by 60.
+                rol remainder+2         ;   division of a two-byte value by 60.
                 
                 sec
-                lda remainder
+                lda remainder+2
                 sbc #60
                 
                 bcc @secignore
                 
-                sta remainder
+                sta remainder+2
 	
 @secignore:	
                 dex

--- a/petclock.asm
+++ b/petclock.asm
@@ -539,7 +539,7 @@ LoadJiffyClock:
                 lda remainder+1         ; Put the low byte of the remainder in the result 
                 sta zptmp               ;   variable.
 
-                ; Extract seconds from jiffy clock. We need one remainder bytes and one result
+                ; Extract seconds from jiffy clock. We need one remainder byte and one result
                 ;   byte because divisor and result are both < 256
                 rol zptmp               ; Like before, rotate left by two bits. Like with 
                 rol remainder+2         ;   minutes, the maximum value of seconds is 59.

--- a/petclock.asm
+++ b/petclock.asm
@@ -336,7 +336,7 @@ SetSeconds:
 
                 clc                     ; Clear carry for first addition
 
-@loop:          adc #60                 ; Add 60 jiffies for each second. If we've
+@loop:          adc #SECOND_JIFFIES     ; Add 60 jiffies for each second. If we've
                 bcc @nextsec            ;   overflown the low byte then increase
                 iny                     ;   the high byte and clear carry again
                 clc


### PR DESCRIPTION
This loads the initial time from the jiffy clock instead of a fixed string value. This means that the time can be set in 24-hour format in BASIC before the clock is started, using:

```basic
TI$="212345"
```

When the time is loaded from the petSD+ or the jiffy clock when (re)initializing the clock, seconds are also considered. Particularly in case a petSD+ is present, this makes that the turn of the minute will be more or less in sync with the actual time.