### PR TITLE
Put build-time settings in separate include

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Source code to [Dave's Garage](https://www.youtube.com/c/DavesGarage/featured) v
 
 ## Configuring and building
 
-Towards the top of the [`petclock.asm`](petclock.asm) file, a number of symbols are defined that can be used to configure the build:
+In the [`settings.inc`](settings.inc) file, a number of symbols are defined that can be used to configure the build:
 |Name|Possible values|Meaning|
 |-|-|-|
 |COLUMNS|40 or 80|Screen width of the target machine, in columns.|
 |DEBUG|0 or 1|Set to 1 to enable code that only is included for debug builds.|
+|DEVICE_NUM|8 to 15|Device number of the petSD+. Only used if PETSDPLUS=1.|
 |EPROM|0 or 1|When set to 1, the BASIC stub and load address will not be included in the build output.|
-|PET|1|Configure build for the PET. Always set to 1.|
 |PETSDPLUS|0 or 1|When set to 1, the clock will read RTC from petSD+ instead of the jiffy timer.|
 |SHOWAMDEFAULT|0 or 1|Set to 1 to use a dot separator for AM and colon for PM. Otherwise, the separator is a colon at all times.|
 

--- a/petclock.asm
+++ b/petclock.asm
@@ -17,12 +17,10 @@
 ; The hours can be specified in 24-hour format; they will be converted to 12-hour
 ; format, as is the time read from the petSD+.
 
-
-.SETCPU "65C02"
-
 .INCLUDE "settings.inc"
 
 ; Definitions -----------------------------------------------------------------------
+
 PET             = 1
 MINUTE_JIFFIES  = 3600              ; Number of jiffies in a minute
 SECOND_JIFFIES  = 60                ; Number of jiffies in a second
@@ -830,6 +828,7 @@ UpdateClock:
 
 @noupdate:      rts
 
+.if PETSDPLUS
 
 ;----------------------------------------------------------------------------
 ; SendCommand
@@ -879,19 +878,19 @@ GetDeviceStatus:
                 sta SA
                 jsr SECND               ; send secondary address
                 ldy #$00
-:
-                phy
-                jsr ACPTR               ; read byte from IEEE bus
-                ply
-                cmp #CR                 ; last byte = CR?
-                beq @done
-                sta DevResponse, y
+:                
+	            jsr ACPTR       	    ; read byte from IEEE bus
+	            cmp #CR				    ; last byte = CR?
+	            beq @done
+	            sta DevResponse, y
                 iny
                 jmp :-                  ; branch always
 @done:          lda #$00
                 sta DevResponse, y      ; null terminate the buffer instead of CR
                 jsr UNTLK               ; UNTALK
                 rts
+
+.endif
 
 ;-----------------------------------------------------------------------------------
 ; Increment/Decrement Hour/Minute

--- a/petclock.asm
+++ b/petclock.asm
@@ -20,17 +20,10 @@
 
 .SETCPU "65C02"
 
+.INCLUDE "settings.inc"
+
 ; Definitions -----------------------------------------------------------------------
 PET             = 1
-DEBUG           = 1					; Enable code that only is included for debug builds
-EPROM           = 0					; When TRUE, no BASIC stub, no load address in file
-PETSDPLUS       = 0                 ; When TRUE, read RTC from petSD+
-SHOWAMDEFAULT   = 1                 ; Use a dot separator for AM and colon for PM
-COLUMNS         = 40                ; Screen width, either 40 or 80
-
-; Defines below this line should generally not require changing
-
-DEVICE_NUM      = 9
 MINUTE_JIFFIES  = 3600              ; Number of jiffies in a minute
 SECOND_JIFFIES  = 60                ; Number of jiffies in a second
 

--- a/petclock.asm
+++ b/petclock.asm
@@ -531,7 +531,7 @@ LoadJiffyClock:
                 bne @hhrol
                 
                 ldx #5                  ; We will perform a 5 step long division
-	
+
 @hhdiv:         rol zptmp               ; Rotate result and remainder left
                 rol remainder
                 rol remainder+1
@@ -554,7 +554,7 @@ LoadJiffyClock:
                 sta remainder+1
                 tya
                 sta remainder
-	
+
 @hhignore:      dex                     ; Continue if we have more division steps to take
                 bne @hhdiv
                 
@@ -578,7 +578,7 @@ LoadJiffyClock:
                 rol remainder+2
                 
                 ldx #6                  ; Perform a 6 step long division
-	
+
 @mmdiv:         rol zptmp               ; Rotate result and remainder left
                 rol remainder+1
                 rol remainder+2
@@ -595,12 +595,12 @@ LoadJiffyClock:
                 sta remainder+2         ; Subtract was possible, so save the remaining
                 tya                     ;   value of the remainder in memory.
                 sta remainder+1
-	
+
 @mmignore:	    dex                     ; Continue if we have more division steps to take
                 bne @mmdiv
                 
                 rol zptmp               ; Don't forget to shift the last bit into the result
-	
+
                 ldx zptmp
                 jsr GetDigitChars       ; Split and store the digits of the calculated
                 stx ClkMinTens          ;   minute value.
@@ -617,7 +617,7 @@ LoadJiffyClock:
                 rol remainder+2
 
                 ldx #6                  ; 6 step long division, like before.
-	
+
 @secdiv:        rol zptmp               ; The below is a pretty straightforward long  
                 rol remainder+2         ;   division of a two-byte value by 60.
                 
@@ -628,12 +628,12 @@ LoadJiffyClock:
                 bcc @secignore
                 
                 sta remainder+2
-	
+
 @secignore:	    dex
                 bne @secdiv
                 
                 rol zptmp
-	
+
                 ldx zptmp
                 jsr GetDigitChars       ; Split and store the digits of the calculated  
                 stx ClkSecTens          ;   second value.
@@ -655,13 +655,13 @@ GetDigitChars:
                 ldx #0
                 
                 sec
-	
+
 @tensloop:      sbc #10                 ; Subtract 10 until we dive below zero. Every
                 bcc @belowzero          ;   time we stay above zero, we increase X.
                 
                 inx
                 bcs @tensloop
-	
+
 @belowzero:     adc #'0'+10             ; Calculate digit character and put it in Y
                 tay
                 
@@ -842,22 +842,22 @@ CommandText:     .literal "T-RI",0      ; Command to read RTC in the petSD+
 SendCommand:    stx zptmpC
                 sty zptmpC+1
 
-	            lda #DEVICE_NUM         ; Device 8 or 9, etc
-	            sta DN
-	            lda #$6f			    ; DATA SA 15 (Must have $#60 or'd in)
-	            sta SA
-	            jsr LISTN   		    ; LISTEN
-	            lda SA
-	            jsr SECND       		; send secondary address
+                lda #DEVICE_NUM         ; Device 8 or 9, etc
+                sta DN
+                lda #$6f			    ; DATA SA 15 (Must have $#60 or'd in)
+                sta SA
+                jsr LISTN   		    ; LISTEN
+                lda SA
+                jsr SECND       		; send secondary address
                 ldy #0
 :               lda (zptmpC), y
                 beq @done
-	            jsr CIOUT           	; send char to IEEE
+                jsr CIOUT           	; send char to IEEE
                 iny
                 bne :-
 
 @done:
-            	jsr UNLSN               ; Unlisten
+                jsr UNLSN               ; Unlisten
                 rts
 
 ;----------------------------------------------------------------------------
@@ -872,26 +872,26 @@ SendCommand:    stx zptmpC
 ;----------------------------------------------------------------------------
 
 GetDeviceStatus:
-	            lda #DEVICE_NUM
-	            sta DN
-	            jsr TALK    			; TALK
-	            lda #$6f			    ; DATA SA 15
-	            sta SA
-	            jsr SECND               ; send secondary address
+                lda #DEVICE_NUM
+                sta DN
+                jsr TALK    			; TALK
+                lda #$6f			    ; DATA SA 15
+                sta SA
+                jsr SECND               ; send secondary address
                 ldy #$00
 :                
                 phy
-	            jsr ACPTR       	    ; read byte from IEEE bus
+                jsr ACPTR       	    ; read byte from IEEE bus
                 ply
-	            cmp #CR				    ; last byte = CR?
-	            beq @done
-	            sta DevResponse, y
+                cmp #CR				    ; last byte = CR?
+                beq @done
+                sta DevResponse, y
                 iny
-	            jmp :-		            ; branch always
+                jmp :-		            ; branch always
 @done:          lda #$00
                 sta DevResponse, y      ; null terminate the buffer instead of CR
-	            jsr UNTLK   		    ; UNTALK
-	            rts
+                jsr UNTLK   		    ; UNTALK
+                rts
 
 ;-----------------------------------------------------------------------------------
 ; Increment/Decrement Hour/Minute

--- a/petclock.asm
+++ b/petclock.asm
@@ -31,9 +31,9 @@ SECOND_JIFFIES  = 60                ; Number of jiffies in a second
 .INCLUDE "basic4.inc"
 
 .if EPROM
-    BASE		= $B000		; Open PET ROM space
+    BASE        = $B000     ; Open PET ROM space
 .else
-    BASE		= $0401		; PET Start of BASIC
+    BASE        = $0401     ; PET Start of BASIC
 .endif
 
 ; System Locations ------------------------------------------------------------------
@@ -47,7 +47,7 @@ zptmp  = $BD
 zptmpB = $00
 zptmpC = $1F
 
-.org 826							; Second cassette buffer on PET
+.org 826                            ; Second cassette buffer on PET
 .bss
 
 
@@ -57,16 +57,16 @@ zptmpC = $1F
 ScratchStart:
    ClockCount:       .res  2            ; 16 bit countup timer to move clock to avoid screen burn
    ClockXPos:        .res  1            ; Current cursor X pos of clock
-   ClockYPos:	     .res  1            ; Current cursor Y pos of clock
-   ClockX:		     .res  1            ; Temp X for clock draw code
-   ClockY:		     .res  1            ; Temp Y for clock draw code
-   temp:			 .res  1            ; General scratch variable
-   bitmask:		     .res  1            ; Bitmask to use to walk through character bitmap row
-   bitcount:		 .res  1            ; Count of which row we're on in bitmap character
-   tempchar:		 .res  1	        ; Scratch variable
-   MultiplyTemp:	 .res  1            ; Scratch variable for multiply code
-   resultLo:		 .res  1			; Results from multiply operations
-   resultHi:		 .res  1
+   ClockYPos:        .res  1            ; Current cursor Y pos of clock
+   ClockX:           .res  1            ; Temp X for clock draw code
+   ClockY:           .res  1            ; Temp Y for clock draw code
+   temp:             .res  1            ; General scratch variable
+   bitmask:          .res  1            ; Bitmask to use to walk through character bitmap row
+   bitcount:         .res  1            ; Count of which row we're on in bitmap character
+   tempchar:         .res  1            ; Scratch variable
+   MultiplyTemp:     .res  1            ; Scratch variable for multiply code
+   resultLo:         .res  1            ; Results from multiply operations
+   resultHi:         .res  1
    remainder:        .res  3            ; Remainder for jiffy load division
    PmFlag:           .res  1            ; Keep track of AM/PM. AM=0, PM=1
    ShowAM:           .res  1            ; Indicate AM with dot instead of colon
@@ -75,13 +75,13 @@ ScratchEnd:
 ; This is where we store the time
 
 ClockStart:
-   HourTens:		 .res  1            ; Various parts of the clock, in text like ASCII '0'
-   HourDigits:	     .res  1
-   MinTens:		     .res  1
-   MinDigits:	     .res  1
-   SecTens:		     .res  1
-   SecDigits:	     .res  1
-   Tenths:		     .res  1
+   HourTens:         .res  1            ; Various parts of the clock, in text like ASCII '0'
+   HourDigits:       .res  1
+   MinTens:          .res  1
+   MinDigits:        .res  1
+   SecTens:          .res  1
+   SecDigits:        .res  1
+   Tenths:           .res  1
 ClockEnd:
 
 ; This is the structure we read the petSD+ clock into for parsing
@@ -107,7 +107,7 @@ DeviceBufferStart:
 DeviceBufferEnd:
 
 .assert (DeviceBufferEnd - DeviceBufferStart) = 23, error   ; Verify length of struct matches fixed RTC format
-.assert * <= 1000, error					                ; Make sure we haven't run off the end of the buffer
+.assert * <= 1000, error                                    ; Make sure we haven't run off the end of the buffer
 
 ; Start of Binary -------------------------------------------------------------------
 
@@ -120,21 +120,21 @@ DeviceBufferEnd:
                 .org 0000
                 .word BASE
                 .org  BASE
-Line10:			.word Line20						; Next line number
-                .word 10							; Line Number 10
-                .byte TK_REM						; REM token
+Line10:         .word Line20                        ; Next line number
+                .word 10                            ; Line Number 10
+                .byte TK_REM                        ; REM token
                 .literal "ARKABLE CLOCK BY DAVEPL (C) 2017", 00
 
-Line20:			.word endOfBasic					; PTR to next line, which is 0000
-                .word 20							; Line Number 20
-                .byte TK_SYS						;   SYS token
+Line20:         .word endOfBasic                    ; PTR to next line, which is 0000
+                .word 20                            ; Line Number 20
+                .byte TK_SYS                        ;   SYS token
                 .literal " "
-                .literal .string(*+7)	    		; Entry is 7 bytes from here, which is
+                .literal .string(*+7)               ; Entry is 7 bytes from here, which is
                                                     ;  not how I'd like to do it but you cannot
                                                     ;  use a forward reference in STR$()
 
-                .byte 00							; Do not modify without understanding
-endOfBasic:		.word 00							;   the +7 expression above, as this is
+                .byte 00                            ; Do not modify without understanding
+endOfBasic:     .word 00                            ;   the +7 expression above, as this is
 .else                                               ;   exactly 7 bytes and must match it
     .org BASE
 .endif
@@ -143,7 +143,7 @@ endOfBasic:		.word 00							;   the +7 expression above, as this is
 ; Start of Code
 ;-----------------------------------------------------------------------------------
 
-start:			cld
+start:          cld
                 jsr InitVariables       ; Since we can be in ROM, zero stuff out
                 jsr LoadClock
 MainLoop:
@@ -152,16 +152,16 @@ MainLoop:
                 ldx ClockXPos
                 jsr DrawClockXY
 
-InnerLoop:		jsr UpdateClockPos      ; Carry will be clear when its time to check
+InnerLoop:      jsr UpdateClockPos      ; Carry will be clear when its time to check
                 bcs MainLoop            ;   keyboard and move clock
 
-                jsr GETIN				; Keyboard Handling - check for input
+                jsr GETIN               ; Keyboard Handling - check for input
                 cmp #0
                 beq InnerLoop
 
                 cmp #$03
                 bne notEscape
-                beq ExitApp				; Escape pressed, go to exit
+                beq ExitApp             ; Escape pressed, go to exit
 
 notEscape:
 
@@ -175,34 +175,34 @@ notEscape:
 .endif
                 cmp #$5A
                 bne @notZero
-                jsr ZeroSeconds		    ; Z pressed, set seconds to 0
+                jsr ZeroSeconds         ; Z pressed, set seconds to 0
                 jmp InnerLoop
 
 @notZero:       cmp #$48
                 bne @notHour
-                jsr IncrementHour		; H pressed, increment hour
+                jsr IncrementHour       ; H pressed, increment hour
                 jmp MainLoop
 
-@notHour:		cmp #$C8
+@notHour:       cmp #$C8
                 bne @notHourDn
-                jsr DecrementHour		; SHIFT-H pressed, decrement hour
+                jsr DecrementHour       ; SHIFT-H pressed, decrement hour
                 jmp MainLoop
 
-@notHourDn:		cmp #$4D
+@notHourDn:     cmp #$4D
                 bne @notMin
-                jsr IncrementMinute		; M pressed, increment minute
+                jsr IncrementMinute     ; M pressed, increment minute
                 jsr ZeroSeconds
                 jmp MainLoop
 
-@notMin:		cmp #$CD
+@notMin:        cmp #$CD
                 bne @notMinDn
-                jsr DecrementMinute		; SHIFT-M pressed, decrement minute
+                jsr DecrementMinute     ; SHIFT-M pressed, decrement minute
                 jsr ZeroSeconds
                 jmp MainLoop
 
-@notMinDn:		cmp #$53
+@notMinDn:      cmp #$53
                 bne @notShowAM
-                jsr ToggleShowAM		; S pressed, toggle show AM flag
+                jsr ToggleShowAM        ; S pressed, toggle show AM flag
                 bcs MainLoop
                 jmp InnerLoop
 
@@ -210,8 +210,8 @@ notEscape:
                 bne @notUpdate
                 jmp MainLoop            ; U pressed, update clock now
 
-@notUpdate:     jsr ShowInstructions	; Any other key shows the help text
-                jmp InnerLoop			;  which gets erased after a few seconds
+@notUpdate:     jsr ShowInstructions    ; Any other key shows the help text
+                jmp InnerLoop           ;  which gets erased after a few seconds
 
 ExitApp:
 .if !PETSDPLUS
@@ -221,7 +221,7 @@ ExitApp:
                 jsr ClearScreen
 
 .if DEBUG
-                ldy #>loadstr		    ; Output load text and exit
+                ldy #>loadstr           ; Output load text and exit
                 lda #<loadstr
                 jsr WriteLine
 .endif
@@ -234,16 +234,16 @@ ExitApp:
 ; it starts out in an unknown state, so we have code to zero it or set it to defaults
 ;-----------------------------------------------------------------------------------
 
-InitVariables:	ldx #ScratchEnd-ScratchStart
-                lda #$00				    ; Init variables to #0
-:				sta ScratchStart, x
+InitVariables:  ldx #ScratchEnd-ScratchStart
+                lda #$00                    ; Init variables to #0
+:               sta ScratchStart, x
                 dex
                 cpx #$ff
                 bne :-
 
-                ldx #ClockEnd-ClockStart	; Init all clock digits to '0'
+                ldx #ClockEnd-ClockStart    ; Init all clock digits to '0'
                 lda #'0'
-:				sta ClockStart, x
+:               sta ClockStart, x
                 dex
                 cpx #$ff
                 bne :-
@@ -262,14 +262,14 @@ InitVariables:	ldx #ScratchEnd-ScratchStart
 ;-----------------------------------------------------------------------------------
 
 UpdateClockPos:
-                inc ClockCount			; Increment the low byte of counter
+                inc ClockCount          ; Increment the low byte of counter
                 bne @nomove
-                inc ClockCount+1		; Increment the high byte
+                inc ClockCount+1        ; Increment the high byte
                 lda ClockCount+1
-                cmp #200				; If high byte hasn't reached 200, a suitable delay, nothing to do
+                cmp #200                ; If high byte hasn't reached 200, a suitable delay, nothing to do
                 bne @nomove
 
-                lda #$0					; Reset wait timer to zero
+                lda #$0                 ; Reset wait timer to zero
                 sta ClockCount
                 sta ClockCount+1
 
@@ -279,7 +279,7 @@ UpdateClockPos:
 
                 inc ClockYPos
                 lda ClockYPos
-                cmp #15					; Don't go lower than this to leave room for instructions
+                cmp #15                 ; Don't go lower than this to leave room for instructions
                 bne @donemove
                 lda #0
                 sta ClockYPos
@@ -287,7 +287,7 @@ UpdateClockPos:
                 sec
                 rts
 
-@nomove:		clc
+@nomove:        clc
                 rts
 
 ;-----------------------------------------------------------------------------------
@@ -295,7 +295,7 @@ UpdateClockPos:
 ;                  Apprently not a complete conversion but it works for my purposes
 ;-----------------------------------------------------------------------------------
 
-ConvertPetSCII:	sta temp
+ConvertPetSCII: sta temp
                 lda #%00100000
                 bit temp
                 bvc :+
@@ -303,7 +303,7 @@ ConvertPetSCII:	sta temp
                 lda temp
                 and #%10011111
                 rts
-:				lda temp
+:               lda temp
                 rts
 
 
@@ -361,22 +361,22 @@ ShowBanner:
                 stx zptmp
                 sty zptmp+1
 
-                lda #$00						; Reset timer counter so banner will stay up a few seconds
+                lda #$00                        ; Reset timer counter so banner will stay up a few seconds
                 sta ClockCount
                 sta ClockCount+1
 
-                lda #<(SCREEN_MEM + 22 * COLUMNS)	; Place instructions at line 22-25 of the screen
+                lda #<(SCREEN_MEM + 22 * COLUMNS)   ; Place instructions at line 22-25 of the screen
                 sta zptmpB
                 lda #>(SCREEN_MEM + 22 * COLUMNS)
                 sta zptmpB+1
                 ldy #0
-@loop:			lda (zptmp),y
+@loop:          lda (zptmp),y
                 beq @done
-                jsr ConvertPetSCII				; Our text is in ASCII, convert to PET screen codes
-@output:		sta (zptmpB),y
+                jsr ConvertPetSCII              ; Our text is in ASCII, convert to PET screen codes
+@output:        sta (zptmpB),y
                 iny
                 bne @loop
-@done:			rts
+@done:          rts
 
 
 ;-----------------------------------------------------------------------------------
@@ -596,7 +596,7 @@ LoadJiffyClock:
                 tya                     ;   value of the remainder in memory.
                 sta remainder+1
 
-@mmignore:	    dex                     ; Continue if we have more division steps to take
+@mmignore:      dex                     ; Continue if we have more division steps to take
                 bne @mmdiv
 
                 rol zptmp               ; Don't forget to shift the last bit into the result
@@ -629,7 +629,7 @@ LoadJiffyClock:
 
                 sta remainder+2
 
-@secignore:	    dex
+@secignore:     dex
                 bne @secdiv
 
                 rol zptmp
@@ -844,15 +844,15 @@ SendCommand:    stx zptmpC
 
                 lda #DEVICE_NUM         ; Device 8 or 9, etc
                 sta DN
-                lda #$6f			    ; DATA SA 15 (Must have $#60 or'd in)
+                lda #$6f                ; DATA SA 15 (Must have $#60 or'd in)
                 sta SA
-                jsr LISTN   		    ; LISTEN
+                jsr LISTN               ; LISTEN
                 lda SA
-                jsr SECND       		; send secondary address
+                jsr SECND               ; send secondary address
                 ldy #0
 :               lda (zptmpC), y
                 beq @done
-                jsr CIOUT           	; send char to IEEE
+                jsr CIOUT               ; send char to IEEE
                 iny
                 bne :-
 
@@ -874,23 +874,23 @@ SendCommand:    stx zptmpC
 GetDeviceStatus:
                 lda #DEVICE_NUM
                 sta DN
-                jsr TALK    			; TALK
-                lda #$6f			    ; DATA SA 15
+                jsr TALK                ; TALK
+                lda #$6f                ; DATA SA 15
                 sta SA
                 jsr SECND               ; send secondary address
                 ldy #$00
 :
                 phy
-                jsr ACPTR       	    ; read byte from IEEE bus
+                jsr ACPTR               ; read byte from IEEE bus
                 ply
-                cmp #CR				    ; last byte = CR?
+                cmp #CR                 ; last byte = CR?
                 beq @done
                 sta DevResponse, y
                 iny
-                jmp :-		            ; branch always
+                jmp :-                  ; branch always
 @done:          lda #$00
                 sta DevResponse, y      ; null terminate the buffer instead of CR
-                jsr UNTLK   		    ; UNTALK
+                jsr UNTLK               ; UNTALK
                 rts
 
 ;-----------------------------------------------------------------------------------
@@ -928,7 +928,7 @@ IncrementHour:
                 eor #1
                 sta PmFlag
 
-@noteleven:     inc HourDigits			; If the hour hit 9, must be 09, so set hour to 10
+@noteleven:     inc HourDigits          ; If the hour hit 9, must be 09, so set hour to 10
                 lda #'9'+1
                 cmp HourDigits
                 bne notNineHour
@@ -938,17 +938,17 @@ IncrementHour:
                 stx HourTens            ; X still holds 1
                 rts
 
-notNineHour:	lda #'2'+1				; If it's past not 2 (ie: possible 12 hour) then skip
+notNineHour:    lda #'2'+1              ; If it's past not 2 (ie: possible 12 hour) then skip
                 cmp HourDigits
-                bne doneHour			; Last digit was 2 but first digit not 1 so go to 3
+                bne doneHour            ; Last digit was 2 but first digit not 1 so go to 3
 
                 cpx HourTens            ; X still holds 1
                 bne doneHour
 
-                lda #'0'				; Roll from 12 to 01
+                lda #'0'                ; Roll from 12 to 01
                 sta HourTens
                 stx HourDigits          ; X still holds 1
-doneHour:		rts
+doneHour:       rts
 
 DecrementMinute:
                 dec MinDigits
@@ -967,7 +967,7 @@ DecrementMinute:
 
 DecrementHour:
                 dec HourDigits
-                lda #'0'-1			    ; If we've gone under zero, must have been 10 so go to 09
+                lda #'0'-1              ; If we've gone under zero, must have been 10 so go to 09
                 cmp HourDigits
                 bne notsubzero
                 lda #'9'
@@ -977,7 +977,7 @@ DecrementHour:
 
                 rts
 
-notsubzero:		lda #'1'-1			    ; If we're going under 1
+notsubzero:     lda #'1'-1              ; If we're going under 1
                 cmp HourDigits
                 bne @chkeleven
                 lda #'0'
@@ -1000,16 +1000,16 @@ notsubzero:		lda #'1'-1			    ; If we're going under 1
                 eor #1
                 sta PmFlag
 
-doneDec:		rts
+doneDec:        rts
 
 ;-----------------------------------------------------------------------------------
-; DrawClockXY	- Draws the current clock at the specified X/Y location on screen
+; DrawClockXY   - Draws the current clock at the specified X/Y location on screen
 ;-----------------------------------------------------------------------------------
-;			X:	Clock X position on screen
-;			Y:	Clock Y position on screen
+;           X:  Clock X position on screen
+;           Y:  Clock Y position on screen
 ;-----------------------------------------------------------------------------------
 
-DrawClockXY:	stx ClockX
+DrawClockXY:    stx ClockX
                 sty ClockY
                 jsr ClearScreen
 
@@ -1022,13 +1022,13 @@ DrawClockXY:	stx ClockX
                 lda HourTens
                 cmp #'0'
                 bne @notZeroHour
-                lda ClockX			; Go left 4 columns (half a big char) to center single-digit hour
+                lda ClockX          ; Go left 4 columns (half a big char) to center single-digit hour
                 sec
                 sbc #4
                 sta ClockX
                 lda HourTens
 
-@notZeroHour:	clc					; Colon	or dot - We draw it first so other characters can overlap it
+@notZeroHour:   clc                 ; Colon or dot - We draw it first so other characters can overlap it
                 lda #15
                 adc ClockX
                 tax
@@ -1047,7 +1047,7 @@ DrawClockXY:	stx ClockX
 @showcolon:     lda #':'
 @drawchar:      jsr DrawBigChar
 
-                clc					; First digit of minutes
+                clc                 ; First digit of minutes
                 lda #21
                 adc ClockX
                 tax
@@ -1058,7 +1058,7 @@ DrawClockXY:	stx ClockX
                 lda MinTens
                 jsr DrawBigChar
 
-                clc					; Second Hour Digit
+                clc                 ; Second Hour Digit
                 lda #8
                 adc ClockX
                 tax
@@ -1069,7 +1069,7 @@ DrawClockXY:	stx ClockX
                 lda HourDigits
                 jsr DrawBigChar
 
-                clc					; First Hour Digit
+                clc                 ; First Hour Digit
                 lda #0
                 adc ClockX
                 tax
@@ -1082,7 +1082,7 @@ DrawClockXY:	stx ClockX
                 beq @skipHourTens
                 jsr DrawBigChar
 @skipHourTens:
-                clc					; 2nd digit of minutes
+                clc                 ; 2nd digit of minutes
                 lda #29
                 adc ClockX
                 tax
@@ -1098,33 +1098,33 @@ DrawClockXY:	stx ClockX
 ;-----------------------------------------------------------------------------------
 ; DrawBigChar - Draws a given big character at the given X/Y positon
 ;-----------------------------------------------------------------------------------
-;			A:	Character to print
-;			X:  X pos on screen
-;			Y:  Y pos on screen
+;           A:  Character to print
+;           X:  X pos on screen
+;           Y:  Y pos on screen
 ;-----------------------------------------------------------------------------------
 
-DrawBigChar:	pha						; Save the A for later, it's the character
-                jsr GetCursorAddr		; Get the screen location based on the X/Y coord
+DrawBigChar:    pha                     ; Save the A for later, it's the character
+                jsr GetCursorAddr       ; Get the screen location based on the X/Y coord
                 stx zptmp
                 sty zptmp+1
                 pla
 
-                jsr GetCharTbl			; Find out the character block memory address
-                stx zptmpB				;   for the character in A
+                jsr GetCharTbl          ; Find out the character block memory address
+                stx zptmpB              ;   for the character in A
                 sty zptmpB+1
 
-                lda #7					; Now do all 7 rows of the character definition
+                lda #7                  ; Now do all 7 rows of the character definition
                 sta bitcount
 
                 ldx #0
-@byteloop:		ldy #0
+@byteloop:      ldy #0
 
-                lda #%10000000			; Bitmask that walks right (10000000, 01000000, etc)
+                lda #%10000000          ; Bitmask that walks right (10000000, 01000000, etc)
                 sta bitmask
 
-@bitloop:		lda (zptmpB,x)			; x must be zero, we want indirect through zptmpB
-                and bitmask				; If this bit is set in the character data, draw a block
-                beq @prtblank			; If not set, skip and draw nothing
+@bitloop:       lda (zptmpB,x)          ; x must be zero, we want indirect through zptmpB
+                and bitmask             ; If this bit is set in the character data, draw a block
+                beq @prtblank           ; If not set, skip and draw nothing
                 lda #160
                 sta (zptmp), y
 .if COLUMNS=80
@@ -1133,22 +1133,22 @@ DrawBigChar:	pha						; Save the A for later, it's the character
 .endif
                 bne @doneprt
 
-@prtblank:		lda #' '
+@prtblank:      lda #' '
                 sta (zptmp), y
 .if COLUMNS=80
                 iny                     ; We have 80 columns, so draw 2 blanks instead of one
                 sta (zptmp), y
 .endif
 
-@doneprt:		lsr bitmask
+@doneprt:       lsr bitmask
                 iny
-                cpy #COLUMNS/5			; 8 bits to do, amounting to 8 or 16 characters
+                cpy #COLUMNS/5          ; 8 bits to do, amounting to 8 or 16 characters
                 bne @bitloop
 
                 inc zptmpB
                 bne @nocarry
                 inc zptmpB+1
-@nocarry:		clc						; Advance the draw point to the next screen line
+@nocarry:       clc                     ; Advance the draw point to the next screen line
                 lda zptmp
                 adc #COLUMNS
                 sta zptmp
@@ -1156,14 +1156,14 @@ DrawBigChar:	pha						; Save the A for later, it's the character
                 adc #0
                 sta zptmp+1
 
-                dec bitcount			; Next character definition row, until all done
+                dec bitcount            ; Next character definition row, until all done
                 bne @byteloop
                 rts
 
 ;-----------------------------------------------------------------------------------
 ; GetCursorAddr - Returns address of X/Y position on screen
 ;-----------------------------------------------------------------------------------
-;		IN  X:	X pos
+;       IN  X:  X pos
 ;       IN  Y:  Y pos
 ;       OUT X:  lsb of address
 ;       OUT Y:  msb of address
@@ -1174,7 +1174,7 @@ GetCursorAddr:  stx temp
                 asl temp                ; We have 80 columns, so double X
 .endif
                 ldx #COLUMNS
-                jsr Multiply			; Result of Y*COLUMNS in AY
+                jsr Multiply            ; Result of Y*COLUMNS in AY
                 sta resultLo
                 sty resultHi
                 lda resultLo
@@ -1183,7 +1183,7 @@ GetCursorAddr:  stx temp
                 bcc nocarry
                 inc resultHi
                 clc
-nocarry:		adc temp
+nocarry:        adc temp
                 sta resultLo
                 lda resultHi
                 adc #>SCREEN_MEM
@@ -1193,10 +1193,10 @@ nocarry:		adc temp
                 rts
 
 ;-----------------------------------------------------------------------------------
-; Multiply		Multiplies X * Y == ResultLo/ResultHi
+; Multiply      Multiplies X * Y == ResultLo/ResultHi
 ;-----------------------------------------------------------------------------------
-;				X		8 bit value in
-;				Y		8 bit value in
+;               X       8 bit value in
+;               Y       8 bit value in
 ;-----------------------------------------------------------------------------------
 
 Multiply:
@@ -1206,16 +1206,16 @@ Multiply:
                 tay
                 sty resultHi
                 beq enterLoop
-doAdd:			clc
+doAdd:          clc
                 adc resultLo
                 tax
                 tya
                 adc resultHi
                 tay
                 txa
-loop:			asl resultLo
-                rol	resultHi
-enterLoop:		lsr MultiplyTemp
+loop:           asl resultLo
+                rol resultHi
+enterLoop:      lsr MultiplyTemp
                 bcs doAdd
                 bne loop
                 rts
@@ -1223,37 +1223,37 @@ enterLoop:		lsr MultiplyTemp
 ;-----------------------------------------------------------------------------------
 ; ClearScreen
 ;-----------------------------------------------------------------------------------
-;			X:	lsb of address of null-terminated string
+;           X:  lsb of address of null-terminated string
 ;           A:  msb of address
 ;-----------------------------------------------------------------------------------
 
-ClearScreen:	jmp CLRSCR
+ClearScreen:    jmp CLRSCR
 
 ;-----------------------------------------------------------------------------------
 ; WriteLine - Writes a line of text to the screen using CHROUT ($FFD2)
 ;-----------------------------------------------------------------------------------
-;			Y:	MSB of address of null-terminated string
+;           Y:  MSB of address of null-terminated string
 ;           A:  LSB
 ;-----------------------------------------------------------------------------------
 
-WriteLine:		sta zptmp
+WriteLine:      sta zptmp
                 sty zptmp+1
                 ldy #0
-@loop:			lda (zptmp),y
+@loop:          lda (zptmp),y
                 beq done
                 jsr CHROUT
                 iny
                 bne @loop
-done: 			rts
+done:           rts
 
 ;-----------------------------------------------------------------------------------
 ; RepeatChar - Writes a character A to the output X times
 ;-----------------------------------------------------------------------------------
-;			A:	Character to write
+;           A:  Character to write
 ;           X:  Number of times to repeat it
 ;-----------------------------------------------------------------------------------
 
-RepeatChar:		jsr CHROUT
+RepeatChar:     jsr CHROUT
                 dex
                 bne RepeatChar
                 rts
@@ -1261,8 +1261,8 @@ RepeatChar:		jsr CHROUT
 ; During development we output the LOAD statement after running to make the
 ; code-test-debug cycle go a little easier - less typing
 
-loadstr:		.literal "LOAD ", 34,"PETCLOCK.PRG",34,", 9",13,0
-hello:			.literal "STARTING PETCLOCK...", 0
+loadstr:        .literal "LOAD ", 34,"PETCLOCK.PRG",34,", 9",13,0
+hello:          .literal "STARTING PETCLOCK...", 0
 
 .endif
 
@@ -1270,32 +1270,32 @@ hello:			.literal "STARTING PETCLOCK...", 0
 ; GetCharTbl - Returns the address of the character block table for whatever petscii
 ;              character is specified in the accumualtor
 ;-----------------------------------------------------------------------------------
-;			A:	Character to look up
+;           A:  Character to look up
 ;       OUT X:  lsb of character map entry
 ;       OUT Y:  msb of character map entry
 ;-----------------------------------------------------------------------------------
 
 
-GetCharTbl:		sta tempchar
+GetCharTbl:     sta tempchar
                 ldx #<CharTable
                 stx zptmpC
                 ldx #>CharTable
                 stx zptmpC+1
                 ldy #0
-@scanloop:		lda (zptmpC),y
-                beq FoundChar				; Hit the null terminator, return the zeros after it
+@scanloop:      lda (zptmpC),y
+                beq FoundChar               ; Hit the null terminator, return the zeros after it
                 cmp tempchar
-                beq FoundChar				; Hit the matching char, return the block address
+                beq FoundChar               ; Hit the matching char, return the block address
                 iny
                 iny
                 iny
-                bne @scanloop				; Nothing found, keep scanning
+                bne @scanloop               ; Nothing found, keep scanning
 
-FoundChar:		iny
-                lda (zptmpC),y				; Low byte of character entry in X
+FoundChar:      iny
+                lda (zptmpC),y              ; Low byte of character entry in X
                 tax
                 iny
-                lda (zptmpC),y				; High byte of character entry in Y
+                lda (zptmpC),y              ; High byte of character entry in Y
                 tay
                 rts
 CharTable:
@@ -1336,93 +1336,93 @@ Char0:
                 .byte   %01100011
                 .byte   %01111111
 Char1:
-                .byte	%00001100
-                .byte	%00011100
-                .byte	%00001100
-                .byte	%00001100
-                .byte	%00001100
-                .byte	%00001100
-                .byte	%00111111
+                .byte   %00001100
+                .byte   %00011100
+                .byte   %00001100
+                .byte   %00001100
+                .byte   %00001100
+                .byte   %00001100
+                .byte   %00111111
 Char2:
-                .byte	%01111111
-                .byte	%00000011
-                .byte	%00000011
-                .byte	%01111111
-                .byte	%01100000
-                .byte	%01100000
-                .byte	%01111111
+                .byte   %01111111
+                .byte   %00000011
+                .byte   %00000011
+                .byte   %01111111
+                .byte   %01100000
+                .byte   %01100000
+                .byte   %01111111
 Char3:
-                .byte	%01111111
-                .byte	%00000011
-                .byte	%00000011
-                .byte	%00011111
-                .byte	%00000011
-                .byte	%00000011
-                .byte	%01111111
+                .byte   %01111111
+                .byte   %00000011
+                .byte   %00000011
+                .byte   %00011111
+                .byte   %00000011
+                .byte   %00000011
+                .byte   %01111111
 Char4:
-                .byte	%01100011
-                .byte	%01100011
                 .byte   %01100011
-                .byte	%01111111
-                .byte	%00000011
-                .byte	%00000011
-                .byte	%00000011
+                .byte   %01100011
+                .byte   %01100011
+                .byte   %01111111
+                .byte   %00000011
+                .byte   %00000011
+                .byte   %00000011
 Char5:
-                .byte	%01111111
-                .byte	%01100000
-                .byte	%01100000
-                .byte	%01111111
-                .byte	%00000011
-                .byte	%00000011
-                .byte	%01111111
+                .byte   %01111111
+                .byte   %01100000
+                .byte   %01100000
+                .byte   %01111111
+                .byte   %00000011
+                .byte   %00000011
+                .byte   %01111111
 Char6:
-                .byte	%01111111
-                .byte	%01100000
-                .byte	%01100000
-                .byte	%01111111
-                .byte	%01100011
-                .byte	%01100011
-                .byte	%01111111
+                .byte   %01111111
+                .byte   %01100000
+                .byte   %01100000
+                .byte   %01111111
+                .byte   %01100011
+                .byte   %01100011
+                .byte   %01111111
 Char7:
-                .byte	%01111111
-                .byte	%00000011
-                .byte	%00000011
-                .byte	%00000011
-                .byte	%00000011
-                .byte	%00000011
-                .byte	%00000011
+                .byte   %01111111
+                .byte   %00000011
+                .byte   %00000011
+                .byte   %00000011
+                .byte   %00000011
+                .byte   %00000011
+                .byte   %00000011
 Char8:
-                .byte	%01111111
-                .byte	%01100011
-                .byte	%01100011
-                .byte	%01111111
-                .byte	%01100011
-                .byte	%01100011
-                .byte	%01111111
+                .byte   %01111111
+                .byte   %01100011
+                .byte   %01100011
+                .byte   %01111111
+                .byte   %01100011
+                .byte   %01100011
+                .byte   %01111111
 Char9:
-                .byte	%01111111
-                .byte	%01100011
-                .byte	%01100011
-                .byte	%01111111
-                .byte	%00000011
-                .byte	%00000011
-                .byte	%00000011
+                .byte   %01111111
+                .byte   %01100011
+                .byte   %01100011
+                .byte   %01111111
+                .byte   %00000011
+                .byte   %00000011
+                .byte   %00000011
 CharColon:
-                .byte	%00000000
-                .byte	%00011000
-                .byte	%00011000
-                .byte	%00000000
-                .byte	%00011000
-                .byte	%00011000
-                .byte	%00000000
+                .byte   %00000000
+                .byte   %00011000
+                .byte   %00011000
+                .byte   %00000000
+                .byte   %00011000
+                .byte   %00011000
+                .byte   %00000000
 CharLowDot:
-                .byte	%00000000
-                .byte	%00000000
-                .byte	%00000000
-                .byte	%00000000
-                .byte	%00011000
-                .byte	%00011000
-                .byte	%00000000
+                .byte   %00000000
+                .byte   %00000000
+                .byte   %00000000
+                .byte   %00000000
+                .byte   %00011000
+                .byte   %00011000
+                .byte   %00000000
 
 .if COLUMNS=80
 Instructions:

--- a/petclock.asm
+++ b/petclock.asm
@@ -9,7 +9,7 @@
 ;            : PET 2001
 ;-----------------------------------------------------------------------------------
 ; On PETs that don't have a petSD+, the clock will be initialized from the internal
-; system (jiffy) clock in the PET. The system clock can be initialized in BASIC 
+; system (jiffy) clock in the PET. The system clock can be initialized in BASIC
 ; before running this clock, by issuing the following command:
 ;
 ; TI$="HHMMSS"
@@ -54,7 +54,7 @@ zptmpC = $1F
 ; These are scratch variables - they are here in the cassette buffer so that we can
 ; be burned into ROM (if we just used .byte we couldn't write values back)
 
-ScratchStart:    
+ScratchStart:
    ClockCount:       .res  2            ; 16 bit countup timer to move clock to avoid screen burn
    ClockXPos:        .res  1            ; Current cursor X pos of clock
    ClockYPos:	     .res  1            ; Current cursor Y pos of clock
@@ -70,15 +70,15 @@ ScratchStart:
    remainder:        .res  3            ; Remainder for jiffy load division
    PmFlag:           .res  1            ; Keep track of AM/PM. AM=0, PM=1
    ShowAM:           .res  1            ; Indicate AM with dot instead of colon
-ScratchEnd:		 
+ScratchEnd:
 
 ; This is where we store the time
 
-ClockStart:		 
+ClockStart:
    HourTens:		 .res  1            ; Various parts of the clock, in text like ASCII '0'
    HourDigits:	     .res  1
    MinTens:		     .res  1
-   MinDigits:	     .res  1	
+   MinDigits:	     .res  1
    SecTens:		     .res  1
    SecDigits:	     .res  1
    Tenths:		     .res  1
@@ -121,7 +121,7 @@ DeviceBufferEnd:
                 .word BASE
                 .org  BASE
 Line10:			.word Line20						; Next line number
-                .word 10							; Line Number 10		
+                .word 10							; Line Number 10
                 .byte TK_REM						; REM token
                 .literal "ARKABLE CLOCK BY DAVEPL (C) 2017", 00
 
@@ -133,11 +133,11 @@ Line20:			.word endOfBasic					; PTR to next line, which is 0000
                                                     ;  not how I'd like to do it but you cannot
                                                     ;  use a forward reference in STR$()
 
-                .byte 00							; Do not modify without understanding 
+                .byte 00							; Do not modify without understanding
 endOfBasic:		.word 00							;   the +7 expression above, as this is
 .else                                               ;   exactly 7 bytes and must match it
     .org BASE
-.endif												
+.endif
 
 ;-----------------------------------------------------------------------------------
 ; Start of Code
@@ -146,9 +146,9 @@ endOfBasic:		.word 00							;   the +7 expression above, as this is
 start:			cld
                 jsr InitVariables       ; Since we can be in ROM, zero stuff out
                 jsr LoadClock
-MainLoop:		
+MainLoop:
                 jsr UpdateClock         ; Update clock values if it's time to do so
-                ldy ClockYPos			
+                ldy ClockYPos
                 ldx ClockXPos
                 jsr DrawClockXY
 
@@ -163,7 +163,7 @@ InnerLoop:		jsr UpdateClockPos      ; Carry will be clear when its time to check
                 bne notEscape
                 beq ExitApp				; Escape pressed, go to exit
 
-notEscape:		
+notEscape:
 
 .if PETSDPLUS
                 cmp #$4C
@@ -173,12 +173,12 @@ notEscape:
 
 @notLoad:
 .endif
-                cmp #$5A				
+                cmp #$5A
                 bne @notZero
                 jsr ZeroSeconds		    ; Z pressed, set seconds to 0
                 jmp InnerLoop
 
-@notZero:       cmp #$48				
+@notZero:       cmp #$48
                 bne @notHour
                 jsr IncrementHour		; H pressed, increment hour
                 jmp MainLoop
@@ -213,7 +213,7 @@ notEscape:
 @notUpdate:     jsr ShowInstructions	; Any other key shows the help text
                 jmp InnerLoop			;  which gets erased after a few seconds
 
-ExitApp:		
+ExitApp:
 .if !PETSDPLUS
                 jsr UpdateJiffyClock    ; Set jiffy clock to our time
 .endif
@@ -228,7 +228,7 @@ ExitApp:
                 rts
 
 ;-----------------------------------------------------------------------------------
-; InitVariables	
+; InitVariables
 ;-----------------------------------------------------------------------------------
 ; We use a bunch of storage in the system (on the PET, it's Cassette Buffer #2) and
 ; it starts out in an unknown state, so we have code to zero it or set it to defaults
@@ -252,9 +252,9 @@ InitVariables:	ldx #ScratchEnd-ScratchStart
                 sta ShowAM
 
                 rts
-                
+
 ;-----------------------------------------------------------------------------------
-; UpdateClockPos - Moves the clock around on the screen so that it doesn't burn 
+; UpdateClockPos - Moves the clock around on the screen so that it doesn't burn
 ;                  into the phosophor quite so much.  Doesn't use the bottom 3
 ;                  rows so that we always have somewhere for instructions.
 ;
@@ -264,19 +264,19 @@ InitVariables:	ldx #ScratchEnd-ScratchStart
 UpdateClockPos:
                 inc ClockCount			; Increment the low byte of counter
                 bne @nomove
-                inc ClockCount+1		; Increment the high byte 
+                inc ClockCount+1		; Increment the high byte
                 lda ClockCount+1
                 cmp #200				; If high byte hasn't reached 200, a suitable delay, nothing to do
                 bne @nomove
-                 
+
                 lda #$0					; Reset wait timer to zero
-                sta ClockCount 
+                sta ClockCount
                 sta ClockCount+1
 
                 lda JIFFY_TIMER
                 and #3
                 sta ClockXPos
-    
+
                 inc ClockYPos
                 lda ClockYPos
                 cmp #15					; Don't go lower than this to leave room for instructions
@@ -291,7 +291,7 @@ UpdateClockPos:
                 rts
 
 ;-----------------------------------------------------------------------------------
-; ConvertPetSCII - Convert .literal ASCI to PET screen code		
+; ConvertPetSCII - Convert .literal ASCI to PET screen code
 ;                  Apprently not a complete conversion but it works for my purposes
 ;-----------------------------------------------------------------------------------
 
@@ -312,7 +312,7 @@ ConvertPetSCII:	sta temp
 ;
 ; Sets the carry flag if the clock should be redrawn after it returns (AM)
 ;-----------------------------------------------------------------------------------
- 
+
 ToggleShowAM:
                 lda ShowAM              ; load show AM flag, flip bit, save
                 eor #1
@@ -342,7 +342,7 @@ ToggleShowAM:
 ;-----------------------------------------------------------------------------------
 ; ShowInstructions - Print the help banner on the bottom three rows
 ;-----------------------------------------------------------------------------------
- 
+
 ShowInstructions:
                 ldx #<Instructions
                 ldy #>Instructions
@@ -360,7 +360,7 @@ ShowInstructions:
 ShowBanner:
                 stx zptmp
                 sty zptmp+1
-                
+
                 lda #$00						; Reset timer counter so banner will stay up a few seconds
                 sta ClockCount
                 sta ClockCount+1
@@ -389,16 +389,16 @@ ZeroSeconds:
                 jmp writeJiffy
 
 ;-----------------------------------------------------------------------------------
-; SetSeconds - Set jiffy timer to a specific number of seconds 
+; SetSeconds - Set jiffy timer to a specific number of seconds
 ;-----------------------------------------------------------------------------------
-;          X:  Number of seconds ( < 60 ) to set the jiffy timer to 
+;          X:  Number of seconds ( < 60 ) to set the jiffy timer to
 ;-----------------------------------------------------------------------------------
 
 SetSeconds:
                 cpx #0                  ; Calculate jiffies if we have seconds to add
                 bne @calcjiffies
 
-                lda #0                  ; Zero out A and proceed to write 
+                lda #0                  ; Zero out A and proceed to write
                 beq writeJiffy
 
 @calcjiffies:   ldy #SECOND_JIFFIES     ; Multiply seconds by jiffies per second
@@ -408,7 +408,7 @@ SetSeconds:
 
 writeJiffy:     ldy #0                  ; Highest byte is always 0
                 sei                     ; Write jiffy timer with interrupts disabled.
-                sta JIFFY_TIMER       
+                sta JIFFY_TIMER
                 stx JIFFY_TIMER-1
                 sty JIFFY_TIMER-2
                 cli
@@ -419,7 +419,7 @@ writeJiffy:     ldy #0                  ; Highest byte is always 0
 ;-----------------------------------------------------------------------------------
 
 LoadClock:
-.if PETSDPLUS  
+.if PETSDPLUS
                 ldx #<CommandText
                 ldy #>CommandText
                 jsr SendCommand         ; Fetch time from Real Time Clock on petSD+
@@ -443,11 +443,11 @@ LoadClock:
                 sta PmFlag              ; It's AM unless we find otherwise
 
                 ; We don't want 24-hour time, so fix it up if needed
-                
-                lda HourTens            
+
+                lda HourTens
                 ldx HourDigits
 
-                cmp #'0'                ; Check if TENS digit is 0 
+                cmp #'0'                ; Check if TENS digit is 0
                 bne @tensnotzero
 
                 cpx #'0'                ; Check if ONES digit is 0. If so, it's
@@ -461,7 +461,7 @@ LoadClock:
                 jmp LoadSeconds
 
 @tensnotzero:   cmp #'2'                ; Check if TENS digits is 2
-                beq TwoInTens           
+                beq TwoInTens
 
                 cpx #'2'                ; If the ONES digit is < 2, we're done
                 bcc LoadSeconds
@@ -482,7 +482,7 @@ LoadSeconds:    ldx SecTens
                 jsr SetSeconds          ;   them.
 
                 rts
-    
+
 TwoInTens:      dec HourTens            ; If it's 2X:XX we go back 12 hours
                 dec HourTens            ; Tens digit goes to zero, we give those
                 lda HourDigits          ;   20 hours to the hours digit.  So by
@@ -494,7 +494,7 @@ TwoInTens:      dec HourTens            ; If it's 2X:XX we go back 12 hours
                 bcc @donedigits         ;   we're done here. Otherwise,
                 sbc #10                 ;   subtract 10 from the digits
                 inc HourTens            ;   and increase the tens value to 1
- 
+
 @donedigits:    sta HourDigits          ; We're good to store our hour digits
                 lda #1
                 sta PmFlag              ; It's definitely PM
@@ -508,48 +508,48 @@ TwoInTens:      dec HourTens            ; If it's 2X:XX we go back 12 hours
 LoadJiffyClock:
                 sei                     ; Load jiffy clock with interrupts disabled.
                 lda JIFFY_TIMER         ;   We put the low byte in the result variable
-                ldx JIFFY_TIMER-1       ;   zptmp, and the two high bytes in the two 
+                ldx JIFFY_TIMER-1       ;   zptmp, and the two high bytes in the two
                 ldy JIFFY_TIMER-2       ;   lowest bytes of the remainder. Together with
-                cli                     ;   the initial rotate left below, this sets us 
+                cli                     ;   the initial rotate left below, this sets us
                 sta zptmp               ;   up for the most efficient division to get the
                 stx remainder           ;   hour value out of the jiffy clock.
                 sty remainder+1
 
                 lda #0                  ; Clear remainder high byte
                 sta remainder+2
-                
+
                 ; Extract hour from jiffy clock. We need 3 remainder bytes and one result
                 ;   byte because the divisor is 3 bytes, and the result < 256
                 ldx #3
 
-@hhrol:         rol zptmp               ; We rotate the result and remainder left 3 bits. 
+@hhrol:         rol zptmp               ; We rotate the result and remainder left 3 bits.
                 rol remainder           ;   We do this knowing that the result can be a
                 rol remainder+1         ;   maximum of 5 bits long (max hour value is 23
                 rol remainder+2         ;   or 10111 in binary).
-                
+
                 dex
                 bne @hhrol
-                
+
                 ldx #5                  ; We will perform a 5 step long division
 
 @hhdiv:         rol zptmp               ; Rotate result and remainder left
                 rol remainder
                 rol remainder+1
                 rol remainder+2
-                
+
                 sec                     ; Subtract the number of jiffies in an hour from the
-                lda remainder           ;   current value in the remainder. That number is 
-                sbc #$c0                ;   216,000 or 34bc0 in hex. 
-                tay 
+                lda remainder           ;   current value in the remainder. That number is
+                sbc #$c0                ;   216,000 or 34bc0 in hex.
+                tay
                 lda remainder+1
                 sbc #$4b
                 sta zptmpB
                 lda remainder+2
                 sbc #$03
-                
+
                 bcc @hhignore           ; If carry was cleared, subtract wasn't possible
-                
-                sta remainder+2         ; Subtract was possible, so save the remaining value 
+
+                sta remainder+2         ; Subtract was possible, so save the remaining value
                 lda zptmpB              ;   of the remainder in memory.
                 sta remainder+1
                 tya
@@ -557,9 +557,9 @@ LoadJiffyClock:
 
 @hhignore:      dex                     ; Continue if we have more division steps to take
                 bne @hhdiv
-                
+
                 rol zptmp               ; Don't forget to shift the last bit into the result
-                
+
                 ldx zptmp
                 jsr GetDigitChars       ; Split the digits of the calculated hour value and
                 stx ClkHourTens         ;   store them in the appropriate fields.
@@ -570,35 +570,35 @@ LoadJiffyClock:
 
                 ; Extract minutes from jiffy clock. We need 2 remainder bytes and one result
                 ;   byte because the divisor is 2 bytes, and the result < 256
-                rol zptmp               ; Rotate left by two bits to set things up for 
+                rol zptmp               ; Rotate left by two bits to set things up for
                 rol remainder+1         ;   the calculation of the minutes. This time, the
-                rol remainder+2         ;   result can be a maximum of 6 bits long (max 
+                rol remainder+2         ;   result can be a maximum of 6 bits long (max
                 rol zptmp               ;   minute value is 59, or 111011 in binary).
                 rol remainder+1
                 rol remainder+2
-                
+
                 ldx #6                  ; Perform a 6 step long division
 
 @mmdiv:         rol zptmp               ; Rotate result and remainder left
                 rol remainder+1
                 rol remainder+2
-                
+
                 sec                     ; Subtract the number of jiffies in a minute from
                 lda remainder+1         ;   the current value in the remainder.
                 sbc #<MINUTE_JIFFIES
                 tay
                 lda remainder+2
                 sbc #>MINUTE_JIFFIES
-                
+
                 bcc @mmignore           ; If carry was cleared, subtract wasn't possible
-                
+
                 sta remainder+2         ; Subtract was possible, so save the remaining
                 tya                     ;   value of the remainder in memory.
                 sta remainder+1
 
 @mmignore:	    dex                     ; Continue if we have more division steps to take
                 bne @mmdiv
-                
+
                 rol zptmp               ; Don't forget to shift the last bit into the result
 
                 ldx zptmp
@@ -606,36 +606,36 @@ LoadJiffyClock:
                 stx ClkMinTens          ;   minute value.
                 sty ClkMinDigits
 
-                lda remainder+1         ; Put the low byte of the remainder in the result 
+                lda remainder+1         ; Put the low byte of the remainder in the result
                 sta zptmp               ;   variable.
 
                 ; Extract seconds from jiffy clock. We need one remainder byte and one result
                 ;   byte because divisor and result are both < 256
-                rol zptmp               ; Like before, rotate left by two bits. Like with 
+                rol zptmp               ; Like before, rotate left by two bits. Like with
                 rol remainder+2         ;   minutes, the maximum value of seconds is 59.
                 rol zptmp
                 rol remainder+2
 
                 ldx #6                  ; 6 step long division, like before.
 
-@secdiv:        rol zptmp               ; The below is a pretty straightforward long  
+@secdiv:        rol zptmp               ; The below is a pretty straightforward long
                 rol remainder+2         ;   division of a two-byte value by 60.
-                
+
                 sec
                 lda remainder+2
                 sbc #SECOND_JIFFIES
-                
+
                 bcc @secignore
-                
+
                 sta remainder+2
 
 @secignore:	    dex
                 bne @secdiv
-                
+
                 rol zptmp
 
                 ldx zptmp
-                jsr GetDigitChars       ; Split and store the digits of the calculated  
+                jsr GetDigitChars       ; Split and store the digits of the calculated
                 stx ClkSecTens          ;   second value.
                 sty ClkSecDigits
 
@@ -645,7 +645,7 @@ LoadJiffyClock:
 ;-----------------------------------------------------------------------------------
 ; GetDigitChars - Calculate the tens and digits characters of the value in X
 ;-----------------------------------------------------------------------------------
-;       IN  X:  value to split and convert 
+;       IN  X:  value to split and convert
 ;       OUT X:  tens character
 ;       OUT Y:  digit character
 ;-----------------------------------------------------------------------------------
@@ -653,23 +653,23 @@ LoadJiffyClock:
 GetDigitChars:
                 txa
                 ldx #0
-                
+
                 sec
 
 @tensloop:      sbc #10                 ; Subtract 10 until we dive below zero. Every
                 bcc @belowzero          ;   time we stay above zero, we increase X.
-                
+
                 inx
                 bcs @tensloop
 
 @belowzero:     adc #'0'+10             ; Calculate digit character and put it in Y
                 tay
-                
+
                 txa                     ; Pull tens out of X and calculate tens character
                 clc
                 adc #'0'
                 tax
-                
+
                 rts
 
 ;-----------------------------------------------------------------------------------
@@ -677,7 +677,7 @@ GetDigitChars:
 ;-----------------------------------------------------------------------------------
 
 UpdateJiffyClock:
-                lda #0                  ; Clear out the remainder buffer. We'll 
+                lda #0                  ; Clear out the remainder buffer. We'll
                 sta remainder           ;   reuse that buffer for this.
                 sta remainder+1
                 sta remainder+2
@@ -690,13 +690,13 @@ UpdateJiffyClock:
                 cmp PmFlag
                 bne @pm
 
-                cpx #12                 ; If it's 12 AM, skip adding hours 
+                cpx #12                 ; If it's 12 AM, skip adding hours
                 beq @addminutes
                 bne @addhours
 
 @pm:            cpx #12                 ; Add 12 hours unless it's 12 PM
-                beq @addhours           
-                
+                beq @addhours
+
                 txa
                 clc
                 adc #12
@@ -765,7 +765,7 @@ UpdateJiffyClock:
 ;-----------------------------------------------------------------------------------
 ;  GetCharsValue - Convert tens and digits character to combined value
 ;-----------------------------------------------------------------------------------
-;       IN  X:  tens digit 
+;       IN  X:  tens digit
 ;       IN  Y:  digit character
 ;       OUT X:  value that characters represent
 ;-----------------------------------------------------------------------------------
@@ -793,7 +793,7 @@ GetCharsValue:
 
 
 ;-----------------------------------------------------------------------------------
-; UpdateClock - Updates the clock (minutes), if a minute has passed 
+; UpdateClock - Updates the clock (minutes), if a minute has passed
 ;-----------------------------------------------------------------------------------
 UpdateClock:
                 ; The numbers between brackets are the machine cycles per instruction
@@ -804,7 +804,7 @@ UpdateClock:
                 cli                     ;                                           (2)
 
                 sec                     ; Subtract the number of jiffies per minute (2)
-                sbc #<MINUTE_JIFFIES    ;   from the jiffy timer value, low byte    (2) 
+                sbc #<MINUTE_JIFFIES    ;   from the jiffy timer value, low byte    (2)
                 sta zptmp               ;   first. Store A in temp, as we need A to (3)
                 txa                     ;   subtract the high byte of the number of (2)
                 sbc #>MINUTE_JIFFIES    ;   jiffies per minute from the middle      (2)
@@ -864,7 +864,7 @@ SendCommand:    stx zptmpC
 ; GetDeviceStatus
 ;----------------------------------------------------------------------------
 ; Reads the response back from the device.   In our case the device is the
-; petSD+ and we've sent it a "t-ti" command to read the clock.  The clock 
+; petSD+ and we've sent it a "t-ti" command to read the clock.  The clock
 ; comes back in the following fixed format:
 ;
 ; 2017-01-09t18:20:54 mon
@@ -879,7 +879,7 @@ GetDeviceStatus:
                 sta SA
                 jsr SECND               ; send secondary address
                 ldy #$00
-:                
+:
                 phy
                 jsr ACPTR       	    ; read byte from IEEE bus
                 ply
@@ -919,29 +919,29 @@ IncrementMinute:
 IncrementHour:
                 ldx #'1'                ; We put 1 in X because we need it for quite a few
                                         ;   things down here
-                cpx HourDigits          ; Check if it's the 11th hour. If so, we're switching 
+                cpx HourDigits          ; Check if it's the 11th hour. If so, we're switching
                 bne @noteleven          ;   from AM to PM or the other way around.
                 cpx HourTens
                 bne @noteleven
 
                 lda PmFlag              ; Load PM flag, flip bit, save
                 eor #1
-                sta PmFlag              
+                sta PmFlag
 
 @noteleven:     inc HourDigits			; If the hour hit 9, must be 09, so set hour to 10
                 lda #'9'+1
                 cmp HourDigits
                 bne notNineHour
-            
+
                 lda #'0'
                 sta HourDigits
                 stx HourTens            ; X still holds 1
                 rts
 
 notNineHour:	lda #'2'+1				; If it's past not 2 (ie: possible 12 hour) then skip
-                cmp HourDigits				
+                cmp HourDigits
                 bne doneHour			; Last digit was 2 but first digit not 1 so go to 3
-                
+
                 cpx HourTens            ; X still holds 1
                 bne doneHour
 
@@ -977,7 +977,7 @@ DecrementHour:
 
                 rts
 
-notsubzero:		lda #'1'-1			    ; If we're going under 1 
+notsubzero:		lda #'1'-1			    ; If we're going under 1
                 cmp HourDigits
                 bne @chkeleven
                 lda #'0'
@@ -998,10 +998,10 @@ notsubzero:		lda #'1'-1			    ; If we're going under 1
 
                 lda PmFlag              ; Load PM flag, flip bit, save
                 eor #1
-                sta PmFlag              
+                sta PmFlag
 
 doneDec:		rts
-        
+
 ;-----------------------------------------------------------------------------------
 ; DrawClockXY	- Draws the current clock at the specified X/Y location on screen
 ;-----------------------------------------------------------------------------------
@@ -1013,7 +1013,7 @@ DrawClockXY:	stx ClockX
                 sty ClockY
                 jsr ClearScreen
 
-                ; If there is no tens digit to the current hour, move the clock 
+                ; If there is no tens digit to the current hour, move the clock
                 ; left by half a digit onscreen to center it, and skip rendering
                 ; the hour tens digit at all.  This could put the clock left edge at
                 ; -4 but it still works just fine because that's added to the digit
@@ -1027,7 +1027,7 @@ DrawClockXY:	stx ClockX
                 sbc #4
                 sta ClockX
                 lda HourTens
-                    
+
 @notZeroHour:	clc					; Colon	or dot - We draw it first so other characters can overlap it
                 lda #15
                 adc ClockX
@@ -1103,7 +1103,7 @@ DrawClockXY:	stx ClockX
 ;			Y:  Y pos on screen
 ;-----------------------------------------------------------------------------------
 
-DrawBigChar:	pha						; Save the A for later, it's the character 
+DrawBigChar:	pha						; Save the A for later, it's the character
                 jsr GetCursorAddr		; Get the screen location based on the X/Y coord
                 stx zptmp
                 sty zptmp+1
@@ -1129,10 +1129,10 @@ DrawBigChar:	pha						; Save the A for later, it's the character
                 sta (zptmp), y
 .if COLUMNS=80
                 iny                     ; We have 80 columns, so draw 2 blocks instead of one
-                sta (zptmp), y          
+                sta (zptmp), y
 .endif
                 bne @doneprt
-            
+
 @prtblank:		lda #' '
                 sta (zptmp), y
 .if COLUMNS=80
@@ -1144,7 +1144,7 @@ DrawBigChar:	pha						; Save the A for later, it's the character
                 iny
                 cpy #COLUMNS/5			; 8 bits to do, amounting to 8 or 16 characters
                 bne @bitloop
-                
+
                 inc zptmpB
                 bne @nocarry
                 inc zptmpB+1
@@ -1252,13 +1252,13 @@ done: 			rts
 ;			A:	Character to write
 ;           X:  Number of times to repeat it
 ;-----------------------------------------------------------------------------------
-            
+
 RepeatChar:		jsr CHROUT
                 dex
                 bne RepeatChar
                 rts
 .if DEBUG
-; During development we output the LOAD statement after running to make the 
+; During development we output the LOAD statement after running to make the
 ; code-test-debug cycle go a little easier - less typing
 
 loadstr:		.literal "LOAD ", 34,"PETCLOCK.PRG",34,", 9",13,0
@@ -1323,7 +1323,7 @@ CharTable:
                 .word  Char8
                 .literal "9"
                 .word  Char9
-                
+
                 .literal 0
                 .word   0
 
@@ -1335,7 +1335,7 @@ Char0:
                 .byte   %01100011
                 .byte   %01100011
                 .byte   %01111111
-Char1:			
+Char1:
                 .byte	%00001100
                 .byte	%00011100
                 .byte	%00001100
@@ -1399,7 +1399,7 @@ Char8:
                 .byte	%01100011
                 .byte	%01100011
                 .byte	%01111111
-Char9:				
+Char9:
                 .byte	%01111111
                 .byte	%01100011
                 .byte	%01100011

--- a/settings.inc
+++ b/settings.inc
@@ -1,0 +1,6 @@
+COLUMNS         = 40                ; Screen width, either 40 or 80
+DEBUG           = 1					; Enable code that only is included for debug builds
+DEVICE_NUM      = 9                 ; Device number of the petSD+; only used if PETSDPLUS=1
+EPROM           = 0					; When TRUE, no BASIC stub, no load address in file
+PETSDPLUS       = 0                 ; When TRUE, read RTC from petSD+
+SHOWAMDEFAULT   = 1                 ; Use a dot separator for AM and colon for PM

--- a/settings.inc
+++ b/settings.inc
@@ -1,6 +1,6 @@
 COLUMNS         = 40    ; Screen width, either 40 or 80
-DEBUG           = 1	    ; Enable code that only is included for debug builds
+DEBUG           = 1     ; Enable code that only is included for debug builds
 DEVICE_NUM      = 9     ; Device number of the petSD+; only used if PETSDPLUS=1
-EPROM           = 0	    ; When TRUE, no BASIC stub, no load address in file
+EPROM           = 0     ; When TRUE, no BASIC stub, no load address in file
 PETSDPLUS       = 0     ; When TRUE, read RTC from petSD+
 SHOWAMDEFAULT   = 1     ; Use a dot separator for AM and colon for PM

--- a/settings.inc
+++ b/settings.inc
@@ -1,6 +1,6 @@
 COLUMNS         = 40    ; Screen width, either 40 or 80
-DEBUG           = 1		; Enable code that only is included for debug builds
+DEBUG           = 1	    ; Enable code that only is included for debug builds
 DEVICE_NUM      = 9     ; Device number of the petSD+; only used if PETSDPLUS=1
-EPROM           = 0		; When TRUE, no BASIC stub, no load address in file
+EPROM           = 0	    ; When TRUE, no BASIC stub, no load address in file
 PETSDPLUS       = 0     ; When TRUE, read RTC from petSD+
 SHOWAMDEFAULT   = 1     ; Use a dot separator for AM and colon for PM

--- a/settings.inc
+++ b/settings.inc
@@ -1,6 +1,6 @@
-COLUMNS         = 40                ; Screen width, either 40 or 80
-DEBUG           = 1					; Enable code that only is included for debug builds
-DEVICE_NUM      = 9                 ; Device number of the petSD+; only used if PETSDPLUS=1
-EPROM           = 0					; When TRUE, no BASIC stub, no load address in file
-PETSDPLUS       = 0                 ; When TRUE, read RTC from petSD+
-SHOWAMDEFAULT   = 1                 ; Use a dot separator for AM and colon for PM
+COLUMNS         = 40    ; Screen width, either 40 or 80
+DEBUG           = 1		; Enable code that only is included for debug builds
+DEVICE_NUM      = 9     ; Device number of the petSD+; only used if PETSDPLUS=1
+EPROM           = 0		; When TRUE, no BASIC stub, no load address in file
+PETSDPLUS       = 0     ; When TRUE, read RTC from petSD+
+SHOWAMDEFAULT   = 1     ; Use a dot separator for AM and colon for PM


### PR DESCRIPTION
This puts the build-time configuration options in a separate include file. This makes them easier to identify and change.