### PR TITLE
Make the C64 use the 6526 TOD clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ With the cc65 toolkit installed and in your PATH, you can build the application 
   cl65 -o petclock.prg --asm-include-dir include --asm-define C64=1 -t none petclock.asm
   ```
 
-
 ## Loading and running
 
 Assuming the petclock.prg file is on a disk in device 8, the clock can be loaded using the following command:

--- a/include/c64.inc
+++ b/include/c64.inc
@@ -22,11 +22,22 @@
 
 ; 6526 addresses
 
-    CIA_TENTHS  = $DC08
-    CIA_SECONDS = $DC09
-    CIA_MINUTES = $DC0A
-    CIA_HOURS   = $DC0B
-    CIA_CRB     = $DD0F
+    CIA1_TA_LO   = $DC04
+    CIA1_TA_HI   = $DC05
+    CIA1_TENTHS  = $DC08
+    CIA1_SECONDS = $DC09
+    CIA1_MINUTES = $DC0A
+    CIA1_HOURS   = $DC0B
+    CIA1_CRA     = $DC0E
+    CIA1_CRB     = $DC0F
+    CIA2_TA_LO   = $DD04
+    CIA2_TA_HI   = $DD05
+    CIA2_TENTHS  = $DD08
+    CIA2_SECONDS = $DD09
+    CIA2_MINUTES = $DD0A
+    CIA2_HOURS   = $DD0B
+    CIA2_CRA     = $DD0E
+    CIA2_CRB     = $DD0F
 
 ; Microsoft BASIC 2.0 ROM Functions
 

--- a/include/c64.inc
+++ b/include/c64.inc
@@ -20,6 +20,14 @@
     zptmpB = $FD
     zptmpC = $22
 
+; 6526 addresses
+
+    CIA_TENTHS  = $DC08
+    CIA_SECONDS = $DC09
+    CIA_MINUTES = $DC0A
+    CIA_HOURS   = $DC0B
+    CIA_CRB     = $DD0F
+
 ; Microsoft BASIC 2.0 ROM Functions
 
 ; $A000	Basic cold start vector ($E394)

--- a/include/common.inc
+++ b/include/common.inc
@@ -6,8 +6,8 @@
 	CLRHOME		= $93 ; clear screen
 	CURDN		= $11 ; cursor down
 
-	MINUTE_JIFFIES = 3600 ; Number of jiffies in a minute
-	SECOND_JIFFIES = 60   ; Number of jiffies in a second
+	SECOND_JIFFIES = 60   				 ; Number of jiffies in a second
+	MINUTE_JIFFIES = 60 * SECOND_JIFFIES ; Number of jiffies in a minute
 
 ;---------- tokens ----------------------------------------------------------
 	TK_MUL		= $ac ; *

--- a/petclock.asm
+++ b/petclock.asm
@@ -131,20 +131,32 @@ DeviceBufferEnd:
 
 ; Macros ---------------------------------------------------------------------------
 
+;-----------------------------------------------------------------------------------
+; ChangeClock - Call routine(s) that change the clock values. The actual routine
+;               call(s) are decorated with machine-specific calls, where needed.
+;               Technically, both parameters to the macro are optional: any empty
+;               parater value is skipped. In the practical sense, using this macro
+;               without at least one parameter is meaningless. 
+;-----------------------------------------------------------------------------------
+;   firstProc:  Address of first routine to call
+;  secondProc:  Address of second routine to call
+;-----------------------------------------------------------------------------------
+
 .macro          ChangeClock firstProc, secondProc
 .if C64
                 jsr ReadCIAClock
 .endif
 .ifnblank firstProc
-                jsr firstProc         ; Invoke first procedure
+                jsr firstProc         ; Invoke first routine
 .endif
 .ifnblank secondProc
-                jsr secondProc        ; Invoke second procedure
+                jsr secondProc        ; Invoke second routine
 .endif
 .if C64
                 jsr WriteCIAClock
 .endif
 .endmacro
+
 
 ; Start of Binary -------------------------------------------------------------------
 
@@ -259,8 +271,8 @@ notEscape:
 @notMinDn:      cmp #$53
                 bne @notShowAM
                 jsr ToggleShowAM        ; S pressed, toggle show AM flag
-                bcs @tomainloop
-                jmp InnerLoop
+                bcs @tomainloop         ; Perform indirect jump: MainLoop is out
+                jmp InnerLoop           ;   of reach for a direct branch.
 @tomainloop:    jmp MainLoop
 
 @notShowAM:     cmp #$55

--- a/petclock.asm
+++ b/petclock.asm
@@ -1192,7 +1192,7 @@ InitCIAClock:
                 ora #$80                ; Configure CIA1 TOD to run at 50Hz
                 bne @setfreq
 
-@pick60hz:      and #$7f                ; Configure CIA1 TOD to run at 50Hz
+@pick60hz:      and #$7f                ; Configure CIA1 TOD to run at 60Hz
 
 @setfreq:       sta CIA1_CRA
 

--- a/petclock.asm
+++ b/petclock.asm
@@ -1204,7 +1204,7 @@ InitCIAClock:
 ;----------------------------------------------------------------------------
 
 ReadCIAClock:
-                ldx CIA1_HOURS           ; We start with hours; this also triggers
+                ldx CIA1_HOURS          ; We start with hours; this also triggers
                 txa                     ;   the CIA TOD clock latch.
                 and #$80                ; Isolate PM bit, and rotate it into the
                 clc                     ;   rightmost bit. Then store it in our
@@ -1217,17 +1217,17 @@ ReadCIAClock:
                 stx HourTens
                 sty HourDigits
 
-                lda CIA1_MINUTES         ; Read minutes, convert and store
+                lda CIA1_MINUTES        ; Read minutes, convert and store
                 jsr BCDToChars
                 stx MinTens
                 sty MinDigits
 
-                lda CIA1_SECONDS         ; Read seconds, convert and store
+                lda CIA1_SECONDS        ; Read seconds, convert and store
                 jsr BCDToChars
                 stx SecTens
                 sty SecDigits
 
-                lda CIA1_TENTHS          ; Load tenths of seconds. This also unlatches
+                lda CIA1_TENTHS         ; Load tenths of seconds. This also unlatches
                 adc #'0'                ;   the TOD clock.
                 sta Tenths
 
@@ -1269,8 +1269,8 @@ WriteCIAClock:
                 and #$7f
                 sta CIA1_CRB
 
-                ldx HourTens             ; Load hour tens and digits chars, convert them
-                ldy HourDigits           ;   to BCD.
+                ldx HourTens            ; Load hour tens and digits chars, convert them
+                ldy HourDigits          ;   to BCD.
                 jsr CharsToBCD
 
                 ldy #0                  ; If the hour is 12, prepare to flip the PM
@@ -1291,7 +1291,7 @@ WriteCIAClock:
                 sty zptmp               ; Store our PM bit XOR bitmask and use it
                 eor zptmp
 
-                sta CIA1_HOURS           ; Write our calculated hours value to the CIA clock
+                sta CIA1_HOURS          ; Write our calculated hours value to the CIA clock
 
                 ldx MinTens             ; Load minute tens and digits chars, convert them
                 ldy MinDigits           ;   to BCD, and write to CIA clock.


### PR DESCRIPTION
This makes the C64 build of the clock use the 6526 CIA Time Of Day clock for most of its timekeeping. It still sets itself to whatever time is in the jiffy timer upon startup, and sets the jiffy timer to what the time in the CIA TOD clock is upon exit. This is mainly to allow  BASIC to easily set and read the time.

As the CIA timer has a much higher accuracy than the jiffy timer, this should make the overall clock much more accurate on the C64.