### PR TITLE
Add jiffy timer lag correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ In the [`settings.inc`](settings.inc) file, a number of symbols are defined that
 |C64|0 or 1|No|Configure build for the Commodore 64. Exactly one of C64 or PET **must** be defined to equal 1.|
 |COLOR|1 to 15|On C64|Color code to use for the characters of the clock. Only used and needed on the Commodore 64. A reference for the color C64 codes can be found [here](https://www.c64-wiki.com/wiki/Color).|
 |COLUMNS|40 or 80|Yes|Screen width of the target machine, in columns.|
-|CORRECTLAG|0 or 1|Yes|Set to 1 to compensate for jiffy timer lag on the PET. The correction is based on the finding that the clock loses about a minute per two hours.|
 |DEBUG|0 or 1|Yes|Set to 1 to enable code that only is included for debug builds.|
 |DEVICE_NUM|8 to 15|With petSD+|Device number of the petSD+. Only used if PETSDPLUS=1.|
 |EPROM|0 or 1|Yes|When set to 1, the BASIC stub and load address will not be included in the build output.|
+|JIFFYLAGCOMP|Integer|Yes|Jiffy timer lag compensation for the PET; this value is deducted from the "official" number of jiffies per minute (i.e. 3600) when deciding if a minute has passed. The default value of 28 is based on the finding that the clock loses slightly less than a minute per two hours on the MiniPET.|
 |PET|0 or 1|No|Configure build for the PET. Exactly one of C64 or PET **must** be defined to equal 1.|
 |PETSDPLUS|0 or 1|Yes|When set to 1, the clock will read RTC from [petSD+](http://petsd.net/) instead of the jiffy timer. Currently, the petSD+ is only supported on the PET.|
 |SHOWAMDEFAULT|0 or 1|Yes|Set to 1 to use a dot separator for AM and colon for PM. Otherwise, the separator is a colon at all times.|

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ In the [`settings.inc`](settings.inc) file, a number of symbols are defined that
 |C64|0 or 1|No|Configure build for the Commodore 64. Exactly one of C64 or PET **must** be defined to equal 1.|
 |COLOR|1 to 15|On C64|Color code to use for the characters of the clock. Only used and needed on the Commodore 64. A reference for the color C64 codes can be found [here](https://www.c64-wiki.com/wiki/Color).|
 |COLUMNS|40 or 80|Yes|Screen width of the target machine, in columns.|
+|CORRECTLAG|0 or 1|Yes|Set to 1 to compensate for jiffy timer lag on the PET. The correction is based on the finding that the clock loses about a minute per two hours.|
 |DEBUG|0 or 1|Yes|Set to 1 to enable code that only is included for debug builds.|
 |DEVICE_NUM|8 to 15|With petSD+|Device number of the petSD+. Only used if PETSDPLUS=1.|
 |EPROM|0 or 1|Yes|When set to 1, the BASIC stub and load address will not be included in the build output.|

--- a/petclock.asm
+++ b/petclock.asm
@@ -1017,10 +1017,10 @@ UpdateClock:
                 cli                     ;                                           (2)
 
                 sec                     ; Subtract the number of jiffies per minute (2)
-                sbc #<MINUTE_JIFFIES    ;   from the jiffy timer value, low byte    (2)
+                sbc #<UPDATE_JIFFIES    ;   from the jiffy timer value, low byte    (2)
                 sta zptmp               ;   first. Store A in temp, as we need A to (3)
                 txa                     ;   subtract the high byte of the number of (2)
-                sbc #>MINUTE_JIFFIES    ;   jiffies per minute from the middle      (2)
+                sbc #>UPDATE_JIFFIES    ;   jiffies per minute from the middle      (2)
                 tax                     ;   jiffy byte. We put that back in X, put  (2)
                 tya                     ;   the highest jiffy value byte into A     (2)
                 sbc #0                  ;   and complete the 3-byte subtract.       (2)

--- a/petclock.inc
+++ b/petclock.inc
@@ -78,11 +78,7 @@
 
     SECOND_JIFFIES  = 60                  ; Number of jiffies in a second
     MINUTE_JIFFIES  = 60 * SECOND_JIFFIES ; Number of jiffies in a minute
-.if CORRECTLAG
-    UPDATE_JIFFIES  = MINUTE_JIFFIES - 30 ; Lag-corrected jiffies between minute updates
-.else
-    UPDATE_JIFFIES  = MINUTE_JIFFIES      ; Ignore jiffy lag
-.endif
+    UPDATE_JIFFIES  = MINUTE_JIFFIES - JIFFYLAGCOMP ; Lag-corrected jiffies between minute updates
     MESSAGE_START   = SCREEN_MEM + 22 * COLUMNS
 
 ;-----------------------------------------------------------------------------------

--- a/petclock.inc
+++ b/petclock.inc
@@ -78,6 +78,11 @@
 
     SECOND_JIFFIES  = 60                  ; Number of jiffies in a second
     MINUTE_JIFFIES  = 60 * SECOND_JIFFIES ; Number of jiffies in a minute
+.if CORRECTLAG
+    UPDATE_JIFFIES  = MINUTE_JIFFIES - 30 ; Lag-corrected jiffies between minute updates
+.else
+    UPDATE_JIFFIES  = MINUTE_JIFFIES      ; Ignore jiffy lag
+.endif
     MESSAGE_START   = SCREEN_MEM + 22 * COLUMNS
 
 ;-----------------------------------------------------------------------------------

--- a/settings.inc
+++ b/settings.inc
@@ -5,7 +5,7 @@ EPROM           = 0     ; When TRUE, no BASIC stub, no load address in file
 PETSDPLUS       = 0     ; When TRUE, read RTC from petSD+. Only supported on PET
 SHOWAMDEFAULT   = 1     ; Use a dot separator for AM and colon for PM
 COLOR           = 5     ; Color to use for the clock characters
-CORRECTLAG      = 1     ; Enable PET jiffy clock lag correction   
+JIFFYLAGCOMP    = 28    ; Jiffy lag compensation value
 
 ; --- Uncomment one of the following two lines to select the build target.
 ;     Alternatively, either symbol can be defined using the ca65/cl65 command line.

--- a/settings.inc
+++ b/settings.inc
@@ -4,7 +4,8 @@ DEVICE_NUM      = 9     ; Device number of the petSD+; only used if PETSDPLUS=1
 EPROM           = 0     ; When TRUE, no BASIC stub, no load address in file
 PETSDPLUS       = 0     ; When TRUE, read RTC from petSD+. Only supported on PET
 SHOWAMDEFAULT   = 1     ; Use a dot separator for AM and colon for PM
-COLOR           = 5     ; Color to use for the clock characters   
+COLOR           = 5     ; Color to use for the clock characters
+CORRECTLAG      = 1     ; Enable PET jiffy clock lag correction   
 
 ; --- Uncomment one of the following two lines to select the build target.
 ;     Alternatively, either symbol can be defined using the ca65/cl65 command line.


### PR DESCRIPTION
This adds a configurable compensation for jiffy timer lag on the PET. This is necessary because the jiffy timer doesn't tick exactly 3600 times per minute.
As the documentation for the setting indicates, the default value of 28 is based on the clock drift I observed on my MiniPET. In fact, the precise compensation value I calculated is 27.625; the difference between the two values represents one minute of clock drift per 160 hours, or 6$2 \over 3$ days. I think that's acceptable, and also as good as it gets without support for fractional numbers on the 6502.